### PR TITLE
peopleView UI 수정 & 모델 반영

### DIFF
--- a/Shared/View/Main/People/Model/Person.swift
+++ b/Shared/View/Main/People/Model/Person.swift
@@ -33,5 +33,8 @@ extension Person {
     
     static func makeStaff() -> [Person] {
         return (1...4).map { Person(imageName: "Placeholder", name: "staff\($0)", organization: "organization\($0)", role: ["staff"], description: "I'm staff\($0)") }
+    
+    static func makeDummy() -> Person {
+        return Person(imageName: "Placeholder", name: "", organization: "", role: [], description: "")
     }
 }

--- a/Shared/View/Main/People/Model/Person.swift
+++ b/Shared/View/Main/People/Model/Person.swift
@@ -7,13 +7,88 @@
 
 import Foundation
 
-struct Person: Hashable, Identifiable {
+struct Person: Hashable, Identifiable, Equatable {
+    static func == (lhs: Person, rhs: Person) -> Bool {
+        return lhs.id == rhs.id
+    }
+    
     let id: UUID = UUID()
     let imageName: String
     let name: String
     let organization: String?
-    let role: [String]
+    let role: [PersonRole]
     let description: String
+    let sns: [SNS]
+    
+    init(name: String, organization: String, role: [PersonRole], description: String, sns: [SNS]) {
+        self.name = name
+        self.imageName = "2020_\(name)"
+        self.organization = organization
+        self.role = role
+        self.description = description
+        self.sns = sns
+    }
+}
+
+enum PersonRole: Hashable {
+    case devApp
+    case staff
+    case planner
+    case sponsor
+    case organizer
+    
+    var localizedString: String {
+        switch self {
+        case .devApp:
+            return "앱 개발"
+        case .organizer:
+            return "Organizer"
+        case .planner:
+            return "행사 기획"
+        case .sponsor:
+            return "후원"
+        case .staff:
+            return "행사 진행"
+        }
+    }
+}
+
+enum SNS: Hashable {
+    case email(String)
+    case gitHub(String)
+    case instagram(String)
+    case faceBook(String)
+    case twitter(String)
+    case blog(String)
+    case linkedIn(String)
+    
+    var localizedString: String {
+        switch self {
+        case .email(_):
+            return "Email"
+        case .gitHub(_):
+            return "GitHub"
+        case .instagram(_):
+            return "Instagram"
+        case .faceBook(_):
+            return "FaceBook"
+        case .twitter(_):
+            return "Twitter"
+        case .blog(_):
+            return "Blog"
+        case .linkedIn(_):
+            return "LinkedIn"
+        }
+    }
+    
+    var url: URL? {
+        switch self {
+        case .email(let address):
+            return URL(string: "mailto:\(address)")
+        case .gitHub(let path), .instagram(let path), .faceBook(let path), .twitter(let path), .blog(let path), .linkedIn(let path):
+            return URL(string: path)
+        }
+    }
 }
 
 enum PersonType {
@@ -24,17 +99,133 @@ enum PersonType {
 
 extension Person {
     static func makeOrganizer() -> [Person] {
-        return [Person(imageName: "Placeholder", name: "organizer", organization: nil, role: ["organizer"], description: "I'm organizer")]
+        return [Person.makeDummy()]
     }
     
     static func makePanels() -> [Person] {
-        return (1...6).map { return Person(imageName: "Placeholder", name: "panel\($0)", organization: "organization\($0)", role: ["panel"], description: "I'm panel\($0)") }
+        return [Person.makeDummy()]
     }
     
     static func makeStaff() -> [Person] {
-        return (1...4).map { Person(imageName: "Placeholder", name: "staff\($0)", organization: "organization\($0)", role: ["staff"], description: "I'm staff\($0)") }
+        return [
+            Person(name: "구범모",
+                   organization: "스노우",
+                   role: [.staff, .devApp],
+                   description: "📸 사진 찍기 좋아하는 개발자입니다!",
+                   sns: [
+                    .email("ksquareatm@gmail.com"),
+                    .gitHub("https://github.com/gbmksquare"),
+                    .instagram("https://www.instagram.com/gbmksquare/"),
+                    .faceBook("https://www.facebook.com/gbmksquare"),
+                    .twitter("http://twitter.com/gbmksquare"),
+                    .linkedIn("http://linkedin.com/in/gbmksquare/")
+                   ]),
+            Person(name: "김성훈",
+                   organization: "하이퍼커넥트",
+                   role: [.staff],
+                   description: "내년엔 우리 오프라인으로 만날수 있겠죠?",
+                   sns: [
+                    .gitHub("https://github.com/Seonghun23")
+                   ]),
+            Person(name: "김정",
+                   organization: "코드스쿼드",
+                   role: [.planner, .staff],
+                   description: "나의 작은 발자국이 누군가에게 표식으로 남기를",
+                   sns: [
+                    .email("godrm77@gmail.com"),
+                    .gitHub("https://github.com/godrm"),
+                    .instagram("https://www.instagram.com/godrm"),
+                    .faceBook("https://web.facebook.com/godrm"),
+                    .twitter("https://twitter.com/godrm")
+                   ]),
+            Person(name: "권순길",
+                   organization: "주)에스에이엠티",
+                   role: [.sponsor, .staff],
+                   description: "그냥 그렇게... 그래서 나도...",
+                   sns: [
+                    .email("erikcky77@gmail.colm"),
+                    .instagram("https://www.instagram.com/ricky_kwon/")
+                   ]),
+            Person(name: "박채완",
+                   organization: "네이버 클라우드",
+                   role: [.staff],
+                   description: "의미 있는 개발을 하고 싶습니다.",
+                   sns: [
+                    .email("seizzeday@gmail.com"),
+                    .gitHub("https://github.com/seizze"),
+                    .blog("https://seizze.github.io")
+                   ]),
+            Person(name: "송다영",
+                   organization: "포스타입",
+                   role: [.staff, .devApp],
+                   description: "Code makes world better.",
+                   sns: [
+                    .email("sdy2856@gmail.com"),
+                    .gitHub("https://github.com/delmaSong"),
+                    .instagram("https://www.instagram.com/thinker_yeong/")
+                   ]),
+            Person(name: "신한섭",
+                   organization: "가천대학교",
+                   role: [.staff, .devApp],
+                   description: "끊임없이 배우는 iOS 개발자가 되고싶습니다.",
+                   sns: [
+                    .email("hanseop95@gmail.com"),
+                    .gitHub("https://github.com/1Consumption"),
+                    .instagram("https://www.instagram.com/1consumption/"),
+                    .blog("https://1consumption.github.io")
+                   ]),
+            Person(name: "염도영",
+                   organization: "드라마앤컴퍼니",
+                   role: [.staff, .devApp],
+                   description: "내일은 오늘보다 더 좋은 사람이고 싶습니다.",
+                   sns: [
+                    .email("dyyeom@gmail.com"),
+                    .gitHub("https://github.com/dyyeom"),
+                    .instagram("https://www.instagram.com/dyyeom/"),
+                    .faceBook("https://www.facebook.com/dyyeom"),
+                    .linkedIn("https://www.linkedin.com/in/dyyeom/")
+                   ]),
+            Person(name: "유현식",
+                   organization: "시어스랩",
+                   role: [.staff],
+                   description: "코로나 웨않끝나죠?",
+                   sns: [
+                    .email("dbgustlr92@gmail.com"),
+                    .gitHub("https://github.com/Hyunsik-Yoo"),
+                    .instagram("https://www.instagram.com/hyun_sik_yoo/")
+                   ]),
+            Person(name: "이근나",
+                   organization: "",
+                   role: [.staff],
+                   description: "매일 엊그제보다 더 성장하고 있습니다.👍",
+                   sns: [
+                    .email("keunnalee@gmail.com"),
+                    .gitHub("https://github.com/dev-Lena"),
+                    .instagram("https://www.instagram.com/dev_lena_lee/"),
+                    .blog("https://lena-chamna.netlify.app")
+                   ]),
+            Person(name: "이현호",
+                   organization: "와디즈",
+                   role: [.staff],
+                   description: "노래하는 개발자입니다.",
+                   sns: [
+                    .email("mizzking75@gmail.com"),
+                    .gitHub("https://github.com/m1zz"),
+                    .blog("http://dev200ok.blogspot.com"),
+                    .linkedIn("https://www.linkedin.com/in/hyunholee0705/")
+                   ]),
+            Person(name: "임승혁",
+                   organization: "스윗트래커",
+                   role: [.staff],
+                   description: "매일 매일 기록하기 📖",
+                   sns: [
+                    .gitHub("https://github.com/Limwin94"),
+                    .instagram("https://www.instagram.com/limwin94/")
+                   ])
+        ]
+    }
     
     static func makeDummy() -> Person {
-        return Person(imageName: "Placeholder", name: "", organization: "", role: [], description: "")
+        return Person(name: "신한섭", organization: "", role: [], description: "", sns: [])
     }
 }

--- a/Shared/View/Main/People/PeopleGroupedByRoleView.swift
+++ b/Shared/View/Main/People/PeopleGroupedByRoleView.swift
@@ -10,6 +10,15 @@ import SwiftUI
 struct PeopleGroupedByRoleView: View {
     @EnvironmentObject private var people: People
     
+    var numOfItemsInRow: Int {
+        switch UIDevice.current.model {
+        case "iPhone":
+            return 3
+        default:
+            return 5
+        }
+    }
+    
     var body: some View {
         VStack(spacing: 10) {
             Spacer()
@@ -35,8 +44,9 @@ struct PeopleGroupedByRoleView: View {
             )
             
         default:
+            let row = Int(ceil(Double(people.list.count) / Double(numOfItemsInRow)))
             return AnyView(
-                GridView(rows: people.list.count / 3 + 1, columns: 3, content: { (index) in
+                GridView(rows: row, columns: numOfItemsInRow, content: { (index) in
                     if people.list.count > index {
                         NavigationLink(
                             destination: PersonDetailView(person: people.list[index])) {
@@ -44,6 +54,10 @@ struct PeopleGroupedByRoleView: View {
                                 .frame(width: 80)
                                 .fixedSize(horizontal: true, vertical: false)
                         }
+                    } else {
+                        PersonCell(person: Person.makeDummy())
+                            .frame(width: 80)
+                            .hidden()
                     }
                 })
                 .padding()

--- a/Shared/View/Main/People/PeopleView.swift
+++ b/Shared/View/Main/People/PeopleView.swift
@@ -13,8 +13,8 @@ struct PeopleView: View {
             VStack(spacing: 20) {
                 Image("Placeholder")
                     .resizable()
-                    .frame(maxWidth: 400)
-                    .frame(height: 200)
+                    .aspectRatio(4 / 3, contentMode: .fill)
+                    .frame(maxWidth: .infinity)
                     .cornerRadius(10)
                 PeopleGroupedByRoleView()
                     .environmentObject(People(type: .organizer))

--- a/Shared/View/Main/People/PersonCell.swift
+++ b/Shared/View/Main/People/PersonCell.swift
@@ -56,13 +56,12 @@ struct PersonCell: View {
                 if let organization = person.organization {
                     Text(organization)
                         .font(organizationFont)
-                        .foregroundColor(Color(UIColor.label))
-                        .italic()
+                        .foregroundColor(.gray)
+                        .bold()
                         .minimumScaleFactor(0.5)
                 }
             }
             .lineLimit(1)
-            .multilineTextAlignment(.center)
             Spacer()
         }
     }

--- a/Shared/View/Main/People/PersonCell.swift
+++ b/Shared/View/Main/People/PersonCell.swift
@@ -52,15 +52,17 @@ struct PersonCell: View {
                     .font(titleFont)
                     .foregroundColor(Color(UIColor.label))
                     .bold()
+                    .minimumScaleFactor(0.5)
                 if let organization = person.organization {
                     Text(organization)
                         .font(organizationFont)
                         .foregroundColor(Color(UIColor.label))
                         .italic()
+                        .minimumScaleFactor(0.5)
                 }
             }
+            .lineLimit(1)
             .multilineTextAlignment(.center)
-            .fixedSize(horizontal: false, vertical: true)
             Spacer()
         }
     }

--- a/Shared/View/Main/People/PersonDetailView.swift
+++ b/Shared/View/Main/People/PersonDetailView.swift
@@ -12,56 +12,63 @@ struct PersonDetailView: View {
     
     var body: some View {
         ScrollView {
-            VStack(spacing: 30) {
-                VStack(spacing: 10) {
-                    PersonCell(person: person, type: .large)
-                        .fixedSize(horizontal: /*@START_MENU_TOKEN@*/true/*@END_MENU_TOKEN@*/, vertical: /*@START_MENU_TOKEN@*/true/*@END_MENU_TOKEN@*/)
-                    HStack {
-                        ForEach(person.role, id: \.self) { role in
-                            Text(role)
-                                .font(.body)
-                                .padding([.all], 5)
-                                .overlay(RoundedRectangle(cornerRadius: 5, style: .circular).stroke())
+            HStack {
+                Spacer()
+                VStack(spacing: 30) {
+                    ZStack {
+                        VStack(spacing: 10) {
+                            PersonCell(person: person, type: .large)
+                                .fixedSize(horizontal: true/*@END_MENU_TOKEN@*/, vertical: /*@START_MENU_TOKEN@*/true)
+                            HStack {
+                                ForEach(person.role, id: \.self) { role in
+                                    Text(role.localizedString)
+                                        .font(.caption)
+                                        .padding([.all], 5)
+                                        .overlay(RoundedRectangle(cornerRadius: 5, style: .circular).stroke())
+                                }.foregroundColor(.orange)
+                            }
                         }
                     }
-                }
-                
-                Text(person.description)
-                    .font(.body)
-                    .multilineTextAlignment(.center)
-                    .lineLimit(nil)
-                    .fixedSize(horizontal: false, vertical: /*@START_MENU_TOKEN@*/true/*@END_MENU_TOKEN@*/)
-                
-                VStack {
-                    ForEach(1...3, id: \.self) { _ in
-                        HStack {
-                            Button(action: /*@START_MENU_TOKEN@*/{}/*@END_MENU_TOKEN@*/, label: {
-                                HStack {
-                                    /*@START_MENU_TOKEN@*/Text("Button")/*@END_MENU_TOKEN@*/
-                                        .font(.title3)
-                                        .foregroundColor(.gray)
-                                    Spacer()
-                                    Image(systemName: "arrow.up.right")
-                                        .foregroundColor(.gray)
-                                }
-                            })
+                    
+                    Text(person.description)
+                        .font(.body)
+                        .multilineTextAlignment(.center)
+                        .lineLimit(nil)
+                        .fixedSize(horizontal: false, vertical: true)
+                    
+                    VStack(spacing: 10) {
+                        ForEach(person.sns, id: \.self) { sns in
+                            HStack {
+                                Button(action: {
+                                    guard let url = sns.url else { return }
+                                    UIApplication.shared.open(url)
+                                }, label: {
+                                    HStack {
+                                        Text(sns.localizedString)
+                                            .font(.title3)
+                                            .foregroundColor(.gray)
+                                        Spacer()
+                                        Image(systemName: "arrow.up.right")
+                                            .foregroundColor(.gray)
+                                    }
+                                })
+                            }
+                            .frame(minWidth: /*@START_MENU_TOKEN@*/0/*@END_MENU_TOKEN@*/, idealWidth: /*@START_MENU_TOKEN@*/100/*@END_MENU_TOKEN@*/, maxWidth: 300, minHeight: /*@START_MENU_TOKEN@*/0/*@END_MENU_TOKEN@*/, idealHeight: 50, maxHeight: /*@START_MENU_TOKEN@*/.infinity/*@END_MENU_TOKEN@*/, alignment: /*@START_MENU_TOKEN@*/.center/*@END_MENU_TOKEN@*/)
+                            .padding([.leading, .trailing], 10)
+                            .overlay(RoundedRectangle(cornerRadius: 10).stroke())
                         }
-                        .frame(height: 50)
-                        .padding([.leading, .trailing], 10)
-                        Divider()
+                        .padding([.leading, .trailing], 30)
                     }
                 }
-                .overlay(RoundedRectangle(cornerRadius: 5, style: .circular).stroke())
-                .padding([.leading, .trailing], 30)
+                Spacer()
             }
-            .padding()
         }
-        .navigationBarTitle("Name")
+        .navigationBarTitle(person.name)
     }
 }
 
 struct PersonDetailView_Previews: PreviewProvider {
     static var previews: some View {
-        PersonDetailView(person: People(type: .panels).list[0])
+        PersonDetailView(person: People(type: .staff).list[0])
     }
 }


### PR DESCRIPTION
## 추가한 기능
- SNS 버튼을 누르면 해당 SNS로 이동하게 했습니다. email의 경우는 `mailto`스킴을 사용했습니다. 이를 구분하기 위해 `SNS` enum을 만들어 사용했습니다.(실기기에서는 email 기능이 잘 되는데 시뮬레이터에서는 안되네요...?)
- 현재 Staff만 모델이 제대로 들어가 있는 상태입니다. Organizer, Panels는 더미셀을 집어넣었습니다.

### 마음에 걸리는 점?
- 이미지가 많아서 그런지 people 탭을 누르면 살짝 멈추고 people 탭이 보입니다.

## 수정 사항
#114 수정

- iPad, Mac에서 한 줄에 5명 표시하도록 했습니다. os로 구분 지으려 했는데 잘 안되어서 `UIDevice.current.model`로 구분했습니다. 5명으로 하니까 훨씬 보기 좋네요.
- 말씀하신 헤더 이미지 수정사항을 제가 제대로 이해 했는지 모르겠습니다만, width는 현재 화면의 width에 맞추고, width: height 비율을 4:3으로 줬습니다. 

### 스크린샷
<p float: left>
<img width="200" alt="image" src="https://user-images.githubusercontent.com/37682858/100111039-043b0d00-2eb1-11eb-92bb-77b36fa676de.png">
<img width="200" alt="image" src="https://user-images.githubusercontent.com/37682858/100111048-07ce9400-2eb1-11eb-8e72-8ad5f7dd4637.png">
<img width="200" alt="image" src="https://user-images.githubusercontent.com/37682858/100111061-0ac98480-2eb1-11eb-8489-24dd5b13fa88.png">
</p>

<p float: left>
<img width="300" alt="image" src="https://user-images.githubusercontent.com/37682858/100109771-84607300-2eaf-11eb-9e56-9610f3e80022.png">
<img width="300" alt="image" src="https://user-images.githubusercontent.com/37682858/100109779-86c2cd00-2eaf-11eb-8832-0ed24ef1d9da.png">
<img width="300" alt="image" src="https://user-images.githubusercontent.com/37682858/100109841-9b06ca00-2eaf-11eb-8074-c34a8d0cd0eb.png">
</p>

<p float: left>
<img width="400" alt="image" src="https://user-images.githubusercontent.com/37682858/100109794-8c201780-2eaf-11eb-9898-2198bf93bb04.png">
<img width="400" alt="image" src="https://user-images.githubusercontent.com/37682858/100109804-8fb39e80-2eaf-11eb-9842-62550a82f34f.png">
<img width="400" alt="image" src="https://user-images.githubusercontent.com/37682858/100109833-96421600-2eaf-11eb-92a6-98020a31510b.png">
</p>
