### PR TITLE
schedule notification 기능 추가

### DIFF
--- a/LetSwift.xcodeproj/project.pbxproj
+++ b/LetSwift.xcodeproj/project.pbxproj
@@ -53,6 +53,7 @@
 		A511FC42256BA88D0085CC13 /* PersonCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A511FC41256BA88D0085CC13 /* PersonCell.swift */; };
 		A5346BB2256BB8BB007C41CE /* Person.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5346BB1256BB8BB007C41CE /* Person.swift */; };
 		A56D7F2E256BF1D3003F8336 /* PersonDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A56D7F2D256BF1D3003F8336 /* PersonDetailView.swift */; };
+		A5704B1B256E8E2500EB6C8F /* DateFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5704B1A256E8E2500EB6C8F /* DateFormatter.swift */; };
 		A5EC7768256BD23D0072E959 /* People.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5EC7767256BD23D0072E959 /* People.swift */; };
 		A5EC776F256BE2FB0072E959 /* GridView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5EC776E256BE2FB0072E959 /* GridView.swift */; };
 		A5EC7773256BE3730072E959 /* PeopleGroupedByRoleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5EC7772256BE3730072E959 /* PeopleGroupedByRoleView.swift */; };
@@ -109,6 +110,7 @@
 		A511FC41256BA88D0085CC13 /* PersonCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersonCell.swift; sourceTree = "<group>"; };
 		A5346BB1256BB8BB007C41CE /* Person.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Person.swift; sourceTree = "<group>"; };
 		A56D7F2D256BF1D3003F8336 /* PersonDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersonDetailView.swift; sourceTree = "<group>"; };
+		A5704B1A256E8E2500EB6C8F /* DateFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateFormatter.swift; sourceTree = "<group>"; };
 		A5EC7767256BD23D0072E959 /* People.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = People.swift; sourceTree = "<group>"; };
 		A5EC776E256BE2FB0072E959 /* GridView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GridView.swift; sourceTree = "<group>"; };
 		A5EC7772256BE3730072E959 /* PeopleGroupedByRoleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeopleGroupedByRoleView.swift; sourceTree = "<group>"; };
@@ -301,6 +303,7 @@
 				1624BF97256C7D8500634E29 /* URL.swift */,
 				16DBE6C8256A2EC800B334A3 /* UIApplication.swift */,
 				16DBE6C9256A2EC800B334A3 /* UIColor.swift */,
+				A5704B1A256E8E2500EB6C8F /* DateFormatter.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -445,6 +448,7 @@
 				16984E77256A33970011C872 /* SafariView.swift in Sources */,
 				1624BF90256C4B0D00634E29 /* PastEventItemView.swift in Sources */,
 				16DBE6B1256A283E00B334A3 /* PeopleView.swift in Sources */,
+				A5704B1B256E8E2500EB6C8F /* DateFormatter.swift in Sources */,
 				16984E8F256A378C0011C872 /* SidebarNavigationView.swift in Sources */,
 				A5346BB2256BB8BB007C41CE /* Person.swift in Sources */,
 				1624BF93256C4B6300634E29 /* HeroItemView.swift in Sources */,

--- a/LetSwift.xcodeproj/project.pbxproj
+++ b/LetSwift.xcodeproj/project.pbxproj
@@ -53,6 +53,7 @@
 		A511FC42256BA88D0085CC13 /* PersonCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A511FC41256BA88D0085CC13 /* PersonCell.swift */; };
 		A5346BB2256BB8BB007C41CE /* Person.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5346BB1256BB8BB007C41CE /* Person.swift */; };
 		A56D7F2E256BF1D3003F8336 /* PersonDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A56D7F2D256BF1D3003F8336 /* PersonDetailView.swift */; };
+		A5704B18256E510C00EB6C8F /* UNUserNotificationCenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5704B17256E510C00EB6C8F /* UNUserNotificationCenter.swift */; };
 		A5704B1B256E8E2500EB6C8F /* DateFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5704B1A256E8E2500EB6C8F /* DateFormatter.swift */; };
 		A5EC7768256BD23D0072E959 /* People.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5EC7767256BD23D0072E959 /* People.swift */; };
 		A5EC776F256BE2FB0072E959 /* GridView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5EC776E256BE2FB0072E959 /* GridView.swift */; };
@@ -110,6 +111,7 @@
 		A511FC41256BA88D0085CC13 /* PersonCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersonCell.swift; sourceTree = "<group>"; };
 		A5346BB1256BB8BB007C41CE /* Person.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Person.swift; sourceTree = "<group>"; };
 		A56D7F2D256BF1D3003F8336 /* PersonDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersonDetailView.swift; sourceTree = "<group>"; };
+		A5704B17256E510C00EB6C8F /* UNUserNotificationCenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UNUserNotificationCenter.swift; sourceTree = "<group>"; };
 		A5704B1A256E8E2500EB6C8F /* DateFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateFormatter.swift; sourceTree = "<group>"; };
 		A5EC7767256BD23D0072E959 /* People.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = People.swift; sourceTree = "<group>"; };
 		A5EC776E256BE2FB0072E959 /* GridView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GridView.swift; sourceTree = "<group>"; };
@@ -303,6 +305,7 @@
 				1624BF97256C7D8500634E29 /* URL.swift */,
 				16DBE6C8256A2EC800B334A3 /* UIApplication.swift */,
 				16DBE6C9256A2EC800B334A3 /* UIColor.swift */,
+				A5704B17256E510C00EB6C8F /* UNUserNotificationCenter.swift */,
 				A5704B1A256E8E2500EB6C8F /* DateFormatter.swift */,
 			);
 			path = Extension;
@@ -460,6 +463,7 @@
 				16984E92256A37950011C872 /* TabNavigationView.swift in Sources */,
 				1624BF8A256C4A3700634E29 /* AppSourceCodeItemView.swift in Sources */,
 				6054DA75256A53D500A49BD4 /* EventView.swift in Sources */,
+				A5704B18256E510C00EB6C8F /* UNUserNotificationCenter.swift in Sources */,
 				60E1766F256D507A0068B3F4 /* Data.swift in Sources */,
 				16984E82256A351D0011C872 /* RoundedMask.swift in Sources */,
 				16984E8A256A36000011C872 /* Placeholder.swift in Sources */,

--- a/Shared/Controller/DateManager.swift
+++ b/Shared/Controller/DateManager.swift
@@ -26,8 +26,7 @@ struct DateManager {
     }
     
     func stringDateConvert(date: String, time: String) -> (start: Date, end: Date)? {
-        let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "yyyy년 MM월 dd일 HH:mm"
+        let dateFormatter = DateFormatter.KSTDateFormatter(by: "yyyy년 MM월 dd일 HH:mm")
         
         let startTime = time[time.startIndex...time.index(time.startIndex, offsetBy: 4)]
         let endTime = time[time.index(time.endIndex, offsetBy: -5)...time.index(before: time.endIndex)]

--- a/Shared/Controller/DateManager.swift
+++ b/Shared/Controller/DateManager.swift
@@ -38,3 +38,17 @@ struct DateManager {
         return (startDate, endDate)
     }
 }
+
+extension DateManager {
+    static func makeUserNotification() -> [UserNotificationInfo] {
+        return [
+            UserNotificationInfo("Welcome!", "오늘부터 금요일까지 진행될 레츠스위프트, 준비되셨나요?", 11, 30, 0, 0),
+            UserNotificationInfo("준비하세요!", "\"스위프트, 오픈소스, CoreML\" 세션이 곧 시작됩니다.", 11, 30, 18, 50),
+            UserNotificationInfo("준비하세요!", "\"SwiftUI vs UIKit 끝장토론\" 세션이 곧 시작됩니다.", 12, 1, 18, 50),
+            UserNotificationInfo("준비하세요!", "\"XCode, 패키지 관리, 빌드환경\" 세션이 곧 시작됩니다.", 12, 2, 18, 50),
+            UserNotificationInfo("준비하세요!", "\"아키텍처, 테스트, 배포\" 세션이 곧 시작됩니다.", 12, 3, 18, 50),
+            UserNotificationInfo("준비하세요!", "\"개발문화, 코드리뷰, 기술블로그\" 세션이 곧 시작됩니다.", 12, 4, 18, 50),
+            UserNotificationInfo("GoodBye!", "오늘이 2020 레츠스위프트의 마지막 날입니다. 함께해 주실 거죠?", 12, 4, 0, 0)
+        ]
+    }
+}

--- a/Shared/Extension/DateFormatter.swift
+++ b/Shared/Extension/DateFormatter.swift
@@ -1,0 +1,18 @@
+//
+//  DateFormatter.swift
+//  LetSwift
+//
+//  Created by 신한섭 on 2020/11/25.
+//
+
+import Foundation
+
+extension DateFormatter {
+    static func KSTDateFormatter(by format: String) -> DateFormatter {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = format
+        dateFormatter.timeZone = TimeZone(abbreviation: "KST")
+        
+        return dateFormatter
+    }
+}

--- a/Shared/Extension/UNUserNotificationCenter.swift
+++ b/Shared/Extension/UNUserNotificationCenter.swift
@@ -1,0 +1,38 @@
+//
+//  UNUserNotificationCenter.swift
+//  LetSwift
+//
+//  Created by 신한섭 on 2020/11/25.
+//
+
+import UIKit
+
+typealias UserNotificationInfo = (title: String, message: String, month: Int, day: Int,  hour: Int, minute: Int)
+
+extension UNUserNotificationCenter {
+    static func requestLetSwiftNotification() {
+        guard UserDefaults.standard.value(forKey: "isWillNotify") == nil || UserDefaults.standard.value(forKey: "isWillNotify") as? Bool == false else { return }
+        
+        UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .badge, .sound]) { success, error in
+            if success {
+                DateManager.makeUserNotification().forEach { info in
+                    let content = UNMutableNotificationContent()
+                    content.subtitle = info.title
+                    content.body = info.message
+                    content.sound = UNNotificationSound.default
+                    
+                    let formatter = DateFormatter.KSTDateFormatter(by: "yyyy-MM-dd HH:mm:ss")
+                    guard let date = formatter.date(from: "2020-\(info.month)-\(info.day) \(info.hour):\(info.minute):00") else { return }
+                
+                    let localizedDate = Calendar.current.dateComponents([.year, .month, .day, .hour, .minute, .second], from: date)
+                    let trigger = UNCalendarNotificationTrigger(dateMatching: localizedDate, repeats: false)
+                    let request = UNNotificationRequest(identifier: UUID().uuidString, content: content, trigger: trigger)
+                    
+                    UNUserNotificationCenter.current().add(request)
+                    
+                    UserDefaults.standard.setValue(true, forKey: "isWillNotify")
+                }
+            }
+        }
+    }
+}

--- a/Shared/LetSwiftApp.swift
+++ b/Shared/LetSwiftApp.swift
@@ -26,6 +26,12 @@ struct LetSwiftApp: App {
     var body: some Scene {
         WindowGroup {
             MainView()
+            letSwiftNotification()
         }
+    }
+    
+    func letSwiftNotification() -> EmptyView {
+        UNUserNotificationCenter.requestLetSwiftNotification()
+        return EmptyView()
     }
 }

--- a/Shared/SceneDelegate.swift
+++ b/Shared/SceneDelegate.swift
@@ -18,6 +18,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             window.rootViewController = UIHostingController(rootView: contentView)
             self.window = window
             window.makeKeyAndVisible()
+            UNUserNotificationCenter.requestLetSwiftNotification()
         }
     }
 }

--- a/Shared/View/Main/Schedule/EventView.swift
+++ b/Shared/View/Main/Schedule/EventView.swift
@@ -48,10 +48,12 @@ struct EventView: View {
                         .alert(isPresented: $addScheduleSuccess, content: {
                             Alert(title: Text("알림"), message: Text("일정 등록이 완료되었습니다"), dismissButton: .default(Text("확인")))
                         })
+                        .foregroundColor(Color(UIColor.link))
                 }
                 .frame(minWidth: 0, maxWidth: .infinity, minHeight: 0, maxHeight: 30, alignment: .center)
                 .padding(EdgeInsets(top: 5, leading: 10, bottom: 10, trailing: 10))
             }
+            .foregroundColor(.black)
             .background(Color.white)
         }
         .modifier(RoundedMask())

--- a/Shared/View/Main/Schedule/ScheduleView.swift
+++ b/Shared/View/Main/Schedule/ScheduleView.swift
@@ -9,22 +9,19 @@ import SwiftUI
 
 struct ScheduleView: View {
     var body: some View {
-                ScrollView {
-                    VStack {
-                        EventView(event: events[0])
-                            .padding([.all], 8)
-                        EventView(event: events[1])
-                            .padding([.all], 8)
-                        EventView(event: events[2])
-                            .padding([.all], 8)
-                        EventView(event: events[3])
-                            .padding([.all], 8)
-                        EventView(event: events[4])
-                            .padding([.all], 8)
-                        Text("Schedule")
-                            .navigationTitle("Schedule")
-                    }
-                }
+        ScrollView {
+            VStack {
+                Group {
+                    EventView(event: events[0])
+                    EventView(event: events[1])
+                    EventView(event: events[2])
+                    EventView(event: events[3])
+                    EventView(event: events[4])
+                }.padding([.all], 8)
+                Text("Schedule")
+                    .navigationTitle("Schedule")
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## 추가한 기능
- `UNUserNotificationCenter`를 사용해 local notification 구현. 시작일 00시, 각 세션 시작 10분 전, 종료일 00시에 notification 보냄.

## 변경한 기능
- 현재 모델은 한국 시간을 기준으로 시간정보가 들어가 있음. 그러나, 실행 시키는 지역에 따라 해당 지역을 기준으로 UTC로 변환 됨. 따라서 한국 시간을 기준으로 하기 위해 KST를 TimeZone으로 하는 DateFormatter extension 추가
- 다크모드인 경우 ScheduleView의 Text가 글자 색이 배경색과 겹쳐 안보여서 글자 색을 검정색으로 고정.

### 스크린 샷
<img src = "https://user-images.githubusercontent.com/37682858/100238855-05813e00-2f74-11eb-86f3-7cece2a8569f.png" width = 400 >
