### PR TITLE
Implement WidgetKit Extension

### DIFF
--- a/LetSwift.xcodeproj/project.pbxproj
+++ b/LetSwift.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 52;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -50,6 +50,15 @@
 		60E1766A256D4FBE0068B3F4 /* Event.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60E17669256D4FBE0068B3F4 /* Event.swift */; };
 		60E1766F256D507A0068B3F4 /* Data.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60E1766E256D507A0068B3F4 /* Data.swift */; };
 		60E17672256D509B0068B3F4 /* Event.json in Resources */ = {isa = PBXBuildFile; fileRef = 60E17671256D509B0068B3F4 /* Event.json */; };
+		9A77C72F256EC0B300B30BC6 /* WidgetKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9A77C72E256EC0B300B30BC6 /* WidgetKit.framework */; platformFilter = ios; };
+		9A77C731256EC0B300B30BC6 /* SwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9A77C730256EC0B300B30BC6 /* SwiftUI.framework */; };
+		9A77C734256EC0B300B30BC6 /* ScheduleWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A77C733256EC0B300B30BC6 /* ScheduleWidget.swift */; };
+		9A77C736256EC0B400B30BC6 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9A77C735256EC0B400B30BC6 /* Assets.xcassets */; };
+		9A77C73A256EC0B400B30BC6 /* ScheduleWidgetExtension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 9A77C72C256EC0B300B30BC6 /* ScheduleWidgetExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		9A77C742256EC0BC00B30BC6 /* Event.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60E17669256D4FBE0068B3F4 /* Event.swift */; };
+		9A77C743256EC0BC00B30BC6 /* Data.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60E1766E256D507A0068B3F4 /* Data.swift */; };
+		9A77C746256EC0CC00B30BC6 /* DateManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6054DA7C256A9DBF00A49BD4 /* DateManager.swift */; };
+		9A77C749256EC0E600B30BC6 /* Event.json in Resources */ = {isa = PBXBuildFile; fileRef = 60E17671256D509B0068B3F4 /* Event.json */; };
 		A511FC42256BA88D0085CC13 /* PersonCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A511FC41256BA88D0085CC13 /* PersonCell.swift */; };
 		A5346BB2256BB8BB007C41CE /* Person.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5346BB1256BB8BB007C41CE /* Person.swift */; };
 		A56D7F2E256BF1D3003F8336 /* PersonDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A56D7F2D256BF1D3003F8336 /* PersonDetailView.swift */; };
@@ -57,6 +66,30 @@
 		A5EC776F256BE2FB0072E959 /* GridView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5EC776E256BE2FB0072E959 /* GridView.swift */; };
 		A5EC7773256BE3730072E959 /* PeopleGroupedByRoleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5EC7772256BE3730072E959 /* PeopleGroupedByRoleView.swift */; };
 /* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		9A77C738256EC0B400B30BC6 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 16DBE61C2569EAD100B334A3 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 9A77C72B256EC0B300B30BC6;
+			remoteInfo = ScheduleWidgetExtension;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		9A77C73C256EC0B500B30BC6 /* Embed App Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				9A77C73A256EC0B400B30BC6 /* ScheduleWidgetExtension.appex in Embed App Extensions */,
+			);
+			name = "Embed App Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
 		1624BF05256B734F00634E29 /* NewsletterItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewsletterItemView.swift; sourceTree = "<group>"; };
@@ -106,6 +139,13 @@
 		60E17669256D4FBE0068B3F4 /* Event.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Event.swift; sourceTree = "<group>"; };
 		60E1766E256D507A0068B3F4 /* Data.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Data.swift; sourceTree = "<group>"; };
 		60E17671256D509B0068B3F4 /* Event.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = Event.json; sourceTree = "<group>"; };
+		9A77C72C256EC0B300B30BC6 /* ScheduleWidgetExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = ScheduleWidgetExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		9A77C72E256EC0B300B30BC6 /* WidgetKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WidgetKit.framework; path = Library/Frameworks/WidgetKit.framework; sourceTree = DEVELOPER_DIR; };
+		9A77C730256EC0B300B30BC6 /* SwiftUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftUI.framework; path = System/Library/Frameworks/SwiftUI.framework; sourceTree = SDKROOT; };
+		9A77C733256EC0B300B30BC6 /* ScheduleWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduleWidget.swift; sourceTree = "<group>"; };
+		9A77C735256EC0B400B30BC6 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		9A77C737256EC0B400B30BC6 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		9A77C73B256EC0B400B30BC6 /* ScheduleWidgetExtension.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = ScheduleWidgetExtension.entitlements; sourceTree = "<group>"; };
 		A511FC41256BA88D0085CC13 /* PersonCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersonCell.swift; sourceTree = "<group>"; };
 		A5346BB1256BB8BB007C41CE /* Person.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Person.swift; sourceTree = "<group>"; };
 		A56D7F2D256BF1D3003F8336 /* PersonDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersonDetailView.swift; sourceTree = "<group>"; };
@@ -119,6 +159,15 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		9A77C729256EC0B300B30BC6 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9A77C731256EC0B300B30BC6 /* SwiftUI.framework in Frameworks */,
+				9A77C72F256EC0B300B30BC6 /* WidgetKit.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -163,9 +212,12 @@
 		16DBE61B2569EAD100B334A3 = {
 			isa = PBXGroup;
 			children = (
+				9A77C73B256EC0B400B30BC6 /* ScheduleWidgetExtension.entitlements */,
 				16DBE6982569FCEE00B334A3 /* LetSwift.entitlements */,
 				16DBE6202569EAD100B334A3 /* Shared */,
 				16DBE62A2569EAD200B334A3 /* iOS */,
+				9A77C732256EC0B300B30BC6 /* ScheduleWidget */,
+				9A77C72D256EC0B300B30BC6 /* Frameworks */,
 				16DBE6292569EAD200B334A3 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -190,6 +242,7 @@
 			isa = PBXGroup;
 			children = (
 				16DBE6282569EAD200B334A3 /* LetSwift.app */,
+				9A77C72C256EC0B300B30BC6 /* ScheduleWidgetExtension.appex */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -335,6 +388,25 @@
 			path = Models;
 			sourceTree = "<group>";
 		};
+		9A77C72D256EC0B300B30BC6 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				9A77C72E256EC0B300B30BC6 /* WidgetKit.framework */,
+				9A77C730256EC0B300B30BC6 /* SwiftUI.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		9A77C732256EC0B300B30BC6 /* ScheduleWidget */ = {
+			isa = PBXGroup;
+			children = (
+				9A77C733256EC0B300B30BC6 /* ScheduleWidget.swift */,
+				9A77C735256EC0B400B30BC6 /* Assets.xcassets */,
+				9A77C737256EC0B400B30BC6 /* Info.plist */,
+			);
+			path = ScheduleWidget;
+			sourceTree = "<group>";
+		};
 		A5EC776D256BE2D60072E959 /* Supporting Views */ = {
 			isa = PBXGroup;
 			children = (
@@ -362,15 +434,34 @@
 				16DBE6242569EAD200B334A3 /* Sources */,
 				16DBE6252569EAD200B334A3 /* Frameworks */,
 				16DBE6262569EAD200B334A3 /* Resources */,
+				9A77C73C256EC0B500B30BC6 /* Embed App Extensions */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				9A77C739256EC0B400B30BC6 /* PBXTargetDependency */,
 			);
 			name = LetSwift;
 			productName = "LetSwift (iOS)";
 			productReference = 16DBE6282569EAD200B334A3 /* LetSwift.app */;
 			productType = "com.apple.product-type.application";
+		};
+		9A77C72B256EC0B300B30BC6 /* ScheduleWidgetExtension */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 9A77C73F256EC0B500B30BC6 /* Build configuration list for PBXNativeTarget "ScheduleWidgetExtension" */;
+			buildPhases = (
+				9A77C728256EC0B300B30BC6 /* Sources */,
+				9A77C729256EC0B300B30BC6 /* Frameworks */,
+				9A77C72A256EC0B300B30BC6 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = ScheduleWidgetExtension;
+			productName = ScheduleWidgetExtension;
+			productReference = 9A77C72C256EC0B300B30BC6 /* ScheduleWidgetExtension.appex */;
+			productType = "com.apple.product-type.app-extension";
 		};
 /* End PBXNativeTarget section */
 
@@ -378,11 +469,14 @@
 		16DBE61C2569EAD100B334A3 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 1220;
+				LastSwiftUpdateCheck = 1200;
 				LastUpgradeCheck = 1220;
 				TargetAttributes = {
 					16DBE6272569EAD200B334A3 = {
 						CreatedOnToolsVersion = 12.2;
+					};
+					9A77C72B256EC0B300B30BC6 = {
+						CreatedOnToolsVersion = 12.0.1;
 					};
 				};
 			};
@@ -400,6 +494,7 @@
 			projectRoot = "";
 			targets = (
 				16DBE6272569EAD200B334A3 /* LetSwift */,
+				9A77C72B256EC0B300B30BC6 /* ScheduleWidgetExtension */,
 			);
 		};
 /* End PBXProject section */
@@ -411,6 +506,15 @@
 			files = (
 				60E17672256D509B0068B3F4 /* Event.json in Resources */,
 				16DBE6382569EAD200B334A3 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		9A77C72A256EC0B300B30BC6 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9A77C749256EC0E600B30BC6 /* Event.json in Resources */,
+				9A77C736256EC0B400B30BC6 /* Assets.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -471,7 +575,26 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		9A77C728256EC0B300B30BC6 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9A77C742256EC0BC00B30BC6 /* Event.swift in Sources */,
+				9A77C746256EC0CC00B30BC6 /* DateManager.swift in Sources */,
+				9A77C743256EC0BC00B30BC6 /* Data.swift in Sources */,
+				9A77C734256EC0B300B30BC6 /* ScheduleWidget.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		9A77C739256EC0B400B30BC6 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 9A77C72B256EC0B300B30BC6 /* ScheduleWidgetExtension */;
+			targetProxy = 9A77C738256EC0B400B30BC6 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
 		16DBE63A2569EAD200B334A3 /* Debug */ = {
@@ -588,6 +711,7 @@
 		16DBE63D2569EAD200B334A3 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon_2019_Swift_Light;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = LetSwift.entitlements;
@@ -615,6 +739,7 @@
 		16DBE63E2569EAD200B334A3 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon_2019_Swift_Light;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = LetSwift.entitlements;
@@ -640,6 +765,57 @@
 			};
 			name = Release;
 		};
+		9A77C73D256EC0B500B30BC6 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
+				CODE_SIGN_ENTITLEMENTS = ScheduleWidgetExtension.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = B3PWYBKFUK;
+				INFOPLIST_FILE = ScheduleWidget/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = kr.codesquad.jk.letswift.ScheduleWidget;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SUPPORTS_MACCATALYST = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		9A77C73E256EC0B500B30BC6 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
+				CODE_SIGN_ENTITLEMENTS = ScheduleWidgetExtension.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = B3PWYBKFUK;
+				INFOPLIST_FILE = ScheduleWidget/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = kr.codesquad.jk.letswift.ScheduleWidget;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SUPPORTS_MACCATALYST = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -657,6 +833,15 @@
 			buildConfigurations = (
 				16DBE63D2569EAD200B334A3 /* Debug */,
 				16DBE63E2569EAD200B334A3 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		9A77C73F256EC0B500B30BC6 /* Build configuration list for PBXNativeTarget "ScheduleWidgetExtension" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				9A77C73D256EC0B500B30BC6 /* Debug */,
+				9A77C73E256EC0B500B30BC6 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/LetSwift.xcodeproj/project.pbxproj
+++ b/LetSwift.xcodeproj/project.pbxproj
@@ -59,6 +59,17 @@
 		9A77C743256EC0BC00B30BC6 /* Data.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60E1766E256D507A0068B3F4 /* Data.swift */; };
 		9A77C746256EC0CC00B30BC6 /* DateManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6054DA7C256A9DBF00A49BD4 /* DateManager.swift */; };
 		9A77C749256EC0E600B30BC6 /* Event.json in Resources */ = {isa = PBXBuildFile; fileRef = 60E17671256D509B0068B3F4 /* Event.json */; };
+		9A77C777256EC57300B30BC6 /* WidgetKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9A77C72E256EC0B300B30BC6 /* WidgetKit.framework */; platformFilter = ios; };
+		9A77C778256EC57300B30BC6 /* SwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9A77C730256EC0B300B30BC6 /* SwiftUI.framework */; };
+		9A77C77B256EC57300B30BC6 /* Upcoming1Widget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A77C77A256EC57300B30BC6 /* Upcoming1Widget.swift */; };
+		9A77C77D256EC57400B30BC6 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9A77C77C256EC57400B30BC6 /* Assets.xcassets */; };
+		9A77C781256EC57400B30BC6 /* Upcoming1WidgetExtension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 9A77C776256EC57300B30BC6 /* Upcoming1WidgetExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		9A77C789256EC59300B30BC6 /* Data.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60E1766E256D507A0068B3F4 /* Data.swift */; };
+		9A77C78A256EC59300B30BC6 /* Event.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60E17669256D4FBE0068B3F4 /* Event.swift */; };
+		9A77C78B256EC59300B30BC6 /* Event.json in Resources */ = {isa = PBXBuildFile; fileRef = 60E17671256D509B0068B3F4 /* Event.json */; };
+		9A77C78C256EC59300B30BC6 /* DateManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6054DA7C256A9DBF00A49BD4 /* DateManager.swift */; };
+		9A77C790256EC6AB00B30BC6 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 16DBE6232569EAD200B334A3 /* Assets.xcassets */; };
+		9A77C794256EC6B800B30BC6 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 16DBE6232569EAD200B334A3 /* Assets.xcassets */; };
 		A511FC42256BA88D0085CC13 /* PersonCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A511FC41256BA88D0085CC13 /* PersonCell.swift */; };
 		A5346BB2256BB8BB007C41CE /* Person.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5346BB1256BB8BB007C41CE /* Person.swift */; };
 		A56D7F2E256BF1D3003F8336 /* PersonDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A56D7F2D256BF1D3003F8336 /* PersonDetailView.swift */; };
@@ -75,6 +86,13 @@
 			remoteGlobalIDString = 9A77C72B256EC0B300B30BC6;
 			remoteInfo = ScheduleWidgetExtension;
 		};
+		9A77C77F256EC57400B30BC6 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 16DBE61C2569EAD100B334A3 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 9A77C775256EC57300B30BC6;
+			remoteInfo = Upcoming1WidgetExtension;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -84,6 +102,7 @@
 			dstPath = "";
 			dstSubfolderSpec = 13;
 			files = (
+				9A77C781256EC57400B30BC6 /* Upcoming1WidgetExtension.appex in Embed App Extensions */,
 				9A77C73A256EC0B400B30BC6 /* ScheduleWidgetExtension.appex in Embed App Extensions */,
 			);
 			name = "Embed App Extensions";
@@ -146,6 +165,11 @@
 		9A77C735256EC0B400B30BC6 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		9A77C737256EC0B400B30BC6 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		9A77C73B256EC0B400B30BC6 /* ScheduleWidgetExtension.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = ScheduleWidgetExtension.entitlements; sourceTree = "<group>"; };
+		9A77C776256EC57300B30BC6 /* Upcoming1WidgetExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = Upcoming1WidgetExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		9A77C77A256EC57300B30BC6 /* Upcoming1Widget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Upcoming1Widget.swift; sourceTree = "<group>"; };
+		9A77C77C256EC57400B30BC6 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		9A77C77E256EC57400B30BC6 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		9A77C782256EC57400B30BC6 /* Upcoming1WidgetExtension.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Upcoming1WidgetExtension.entitlements; sourceTree = "<group>"; };
 		A511FC41256BA88D0085CC13 /* PersonCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersonCell.swift; sourceTree = "<group>"; };
 		A5346BB1256BB8BB007C41CE /* Person.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Person.swift; sourceTree = "<group>"; };
 		A56D7F2D256BF1D3003F8336 /* PersonDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersonDetailView.swift; sourceTree = "<group>"; };
@@ -168,6 +192,15 @@
 			files = (
 				9A77C731256EC0B300B30BC6 /* SwiftUI.framework in Frameworks */,
 				9A77C72F256EC0B300B30BC6 /* WidgetKit.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		9A77C773256EC57300B30BC6 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9A77C778256EC57300B30BC6 /* SwiftUI.framework in Frameworks */,
+				9A77C777256EC57300B30BC6 /* WidgetKit.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -212,11 +245,13 @@
 		16DBE61B2569EAD100B334A3 = {
 			isa = PBXGroup;
 			children = (
+				9A77C782256EC57400B30BC6 /* Upcoming1WidgetExtension.entitlements */,
 				9A77C73B256EC0B400B30BC6 /* ScheduleWidgetExtension.entitlements */,
 				16DBE6982569FCEE00B334A3 /* LetSwift.entitlements */,
 				16DBE6202569EAD100B334A3 /* Shared */,
 				16DBE62A2569EAD200B334A3 /* iOS */,
 				9A77C732256EC0B300B30BC6 /* ScheduleWidget */,
+				9A77C779256EC57300B30BC6 /* Upcoming1Widget */,
 				9A77C72D256EC0B300B30BC6 /* Frameworks */,
 				16DBE6292569EAD200B334A3 /* Products */,
 			);
@@ -243,6 +278,7 @@
 			children = (
 				16DBE6282569EAD200B334A3 /* LetSwift.app */,
 				9A77C72C256EC0B300B30BC6 /* ScheduleWidgetExtension.appex */,
+				9A77C776256EC57300B30BC6 /* Upcoming1WidgetExtension.appex */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -407,6 +443,16 @@
 			path = ScheduleWidget;
 			sourceTree = "<group>";
 		};
+		9A77C779256EC57300B30BC6 /* Upcoming1Widget */ = {
+			isa = PBXGroup;
+			children = (
+				9A77C77A256EC57300B30BC6 /* Upcoming1Widget.swift */,
+				9A77C77C256EC57400B30BC6 /* Assets.xcassets */,
+				9A77C77E256EC57400B30BC6 /* Info.plist */,
+			);
+			path = Upcoming1Widget;
+			sourceTree = "<group>";
+		};
 		A5EC776D256BE2D60072E959 /* Supporting Views */ = {
 			isa = PBXGroup;
 			children = (
@@ -440,6 +486,7 @@
 			);
 			dependencies = (
 				9A77C739256EC0B400B30BC6 /* PBXTargetDependency */,
+				9A77C780256EC57400B30BC6 /* PBXTargetDependency */,
 			);
 			name = LetSwift;
 			productName = "LetSwift (iOS)";
@@ -463,6 +510,23 @@
 			productReference = 9A77C72C256EC0B300B30BC6 /* ScheduleWidgetExtension.appex */;
 			productType = "com.apple.product-type.app-extension";
 		};
+		9A77C775256EC57300B30BC6 /* Upcoming1WidgetExtension */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 9A77C785256EC57400B30BC6 /* Build configuration list for PBXNativeTarget "Upcoming1WidgetExtension" */;
+			buildPhases = (
+				9A77C772256EC57300B30BC6 /* Sources */,
+				9A77C773256EC57300B30BC6 /* Frameworks */,
+				9A77C774256EC57300B30BC6 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = Upcoming1WidgetExtension;
+			productName = Upcoming1WidgetExtension;
+			productReference = 9A77C776256EC57300B30BC6 /* Upcoming1WidgetExtension.appex */;
+			productType = "com.apple.product-type.app-extension";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -476,6 +540,9 @@
 						CreatedOnToolsVersion = 12.2;
 					};
 					9A77C72B256EC0B300B30BC6 = {
+						CreatedOnToolsVersion = 12.0.1;
+					};
+					9A77C775256EC57300B30BC6 = {
 						CreatedOnToolsVersion = 12.0.1;
 					};
 				};
@@ -495,6 +562,7 @@
 			targets = (
 				16DBE6272569EAD200B334A3 /* LetSwift */,
 				9A77C72B256EC0B300B30BC6 /* ScheduleWidgetExtension */,
+				9A77C775256EC57300B30BC6 /* Upcoming1WidgetExtension */,
 			);
 		};
 /* End PBXProject section */
@@ -514,7 +582,18 @@
 			buildActionMask = 2147483647;
 			files = (
 				9A77C749256EC0E600B30BC6 /* Event.json in Resources */,
+				9A77C794256EC6B800B30BC6 /* Assets.xcassets in Resources */,
 				9A77C736256EC0B400B30BC6 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		9A77C774256EC57300B30BC6 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9A77C78B256EC59300B30BC6 /* Event.json in Resources */,
+				9A77C790256EC6AB00B30BC6 /* Assets.xcassets in Resources */,
+				9A77C77D256EC57400B30BC6 /* Assets.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -586,6 +665,17 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		9A77C772256EC57300B30BC6 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9A77C77B256EC57300B30BC6 /* Upcoming1Widget.swift in Sources */,
+				9A77C78C256EC59300B30BC6 /* DateManager.swift in Sources */,
+				9A77C78A256EC59300B30BC6 /* Event.swift in Sources */,
+				9A77C789256EC59300B30BC6 /* Data.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -593,6 +683,11 @@
 			isa = PBXTargetDependency;
 			target = 9A77C72B256EC0B300B30BC6 /* ScheduleWidgetExtension */;
 			targetProxy = 9A77C738256EC0B400B30BC6 /* PBXContainerItemProxy */;
+		};
+		9A77C780256EC57400B30BC6 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 9A77C775256EC57300B30BC6 /* Upcoming1WidgetExtension */;
+			targetProxy = 9A77C77F256EC57400B30BC6 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -816,6 +911,57 @@
 			};
 			name = Release;
 		};
+		9A77C783256EC57400B30BC6 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
+				CODE_SIGN_ENTITLEMENTS = Upcoming1WidgetExtension.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = B3PWYBKFUK;
+				INFOPLIST_FILE = Upcoming1Widget/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = kr.codesquad.jk.letswift.Upcoming1Widget;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SUPPORTS_MACCATALYST = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		9A77C784256EC57400B30BC6 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
+				CODE_SIGN_ENTITLEMENTS = Upcoming1WidgetExtension.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = B3PWYBKFUK;
+				INFOPLIST_FILE = Upcoming1Widget/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = kr.codesquad.jk.letswift.Upcoming1Widget;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SUPPORTS_MACCATALYST = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -842,6 +988,15 @@
 			buildConfigurations = (
 				9A77C73D256EC0B500B30BC6 /* Debug */,
 				9A77C73E256EC0B500B30BC6 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		9A77C785256EC57400B30BC6 /* Build configuration list for PBXNativeTarget "Upcoming1WidgetExtension" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				9A77C783256EC57400B30BC6 /* Debug */,
+				9A77C784256EC57400B30BC6 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/LetSwift.xcodeproj/project.pbxproj
+++ b/LetSwift.xcodeproj/project.pbxproj
@@ -70,6 +70,15 @@
 		9A77C78C256EC59300B30BC6 /* DateManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6054DA7C256A9DBF00A49BD4 /* DateManager.swift */; };
 		9A77C790256EC6AB00B30BC6 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 16DBE6232569EAD200B334A3 /* Assets.xcassets */; };
 		9A77C794256EC6B800B30BC6 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 16DBE6232569EAD200B334A3 /* Assets.xcassets */; };
+		9AD49446256EE09900C9E5C4 /* WidgetKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9A77C72E256EC0B300B30BC6 /* WidgetKit.framework */; platformFilter = ios; };
+		9AD49447256EE09900C9E5C4 /* SwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9A77C730256EC0B300B30BC6 /* SwiftUI.framework */; };
+		9AD4944A256EE09900C9E5C4 /* Upcoming2Widget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AD49449256EE09900C9E5C4 /* Upcoming2Widget.swift */; };
+		9AD4944C256EE09B00C9E5C4 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9AD4944B256EE09B00C9E5C4 /* Assets.xcassets */; };
+		9AD49450256EE09B00C9E5C4 /* Upcoming2WidgetExtension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 9AD49445256EE09900C9E5C4 /* Upcoming2WidgetExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		9AD49459256EE10100C9E5C4 /* Data.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60E1766E256D507A0068B3F4 /* Data.swift */; };
+		9AD4945E256EE10300C9E5C4 /* Event.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60E17669256D4FBE0068B3F4 /* Event.swift */; };
+		9AD49463256EE10800C9E5C4 /* DateManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6054DA7C256A9DBF00A49BD4 /* DateManager.swift */; };
+		9AD49468256EE10F00C9E5C4 /* Event.json in Resources */ = {isa = PBXBuildFile; fileRef = 60E17671256D509B0068B3F4 /* Event.json */; };
 		A511FC42256BA88D0085CC13 /* PersonCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A511FC41256BA88D0085CC13 /* PersonCell.swift */; };
 		A5346BB2256BB8BB007C41CE /* Person.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5346BB1256BB8BB007C41CE /* Person.swift */; };
 		A56D7F2E256BF1D3003F8336 /* PersonDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A56D7F2D256BF1D3003F8336 /* PersonDetailView.swift */; };
@@ -93,6 +102,13 @@
 			remoteGlobalIDString = 9A77C775256EC57300B30BC6;
 			remoteInfo = Upcoming1WidgetExtension;
 		};
+		9AD4944E256EE09B00C9E5C4 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 16DBE61C2569EAD100B334A3 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 9AD49444256EE09900C9E5C4;
+			remoteInfo = Upcoming2WidgetExtension;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -104,6 +120,7 @@
 			files = (
 				9A77C781256EC57400B30BC6 /* Upcoming1WidgetExtension.appex in Embed App Extensions */,
 				9A77C73A256EC0B400B30BC6 /* ScheduleWidgetExtension.appex in Embed App Extensions */,
+				9AD49450256EE09B00C9E5C4 /* Upcoming2WidgetExtension.appex in Embed App Extensions */,
 			);
 			name = "Embed App Extensions";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -170,6 +187,11 @@
 		9A77C77C256EC57400B30BC6 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		9A77C77E256EC57400B30BC6 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		9A77C782256EC57400B30BC6 /* Upcoming1WidgetExtension.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Upcoming1WidgetExtension.entitlements; sourceTree = "<group>"; };
+		9AD49445256EE09900C9E5C4 /* Upcoming2WidgetExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = Upcoming2WidgetExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		9AD49449256EE09900C9E5C4 /* Upcoming2Widget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Upcoming2Widget.swift; sourceTree = "<group>"; };
+		9AD4944B256EE09B00C9E5C4 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		9AD4944D256EE09B00C9E5C4 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		9AD49451256EE09B00C9E5C4 /* Upcoming2WidgetExtension.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Upcoming2WidgetExtension.entitlements; sourceTree = "<group>"; };
 		A511FC41256BA88D0085CC13 /* PersonCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersonCell.swift; sourceTree = "<group>"; };
 		A5346BB1256BB8BB007C41CE /* Person.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Person.swift; sourceTree = "<group>"; };
 		A56D7F2D256BF1D3003F8336 /* PersonDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersonDetailView.swift; sourceTree = "<group>"; };
@@ -201,6 +223,15 @@
 			files = (
 				9A77C778256EC57300B30BC6 /* SwiftUI.framework in Frameworks */,
 				9A77C777256EC57300B30BC6 /* WidgetKit.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		9AD49442256EE09900C9E5C4 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9AD49447256EE09900C9E5C4 /* SwiftUI.framework in Frameworks */,
+				9AD49446256EE09900C9E5C4 /* WidgetKit.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -245,6 +276,7 @@
 		16DBE61B2569EAD100B334A3 = {
 			isa = PBXGroup;
 			children = (
+				9AD49451256EE09B00C9E5C4 /* Upcoming2WidgetExtension.entitlements */,
 				9A77C782256EC57400B30BC6 /* Upcoming1WidgetExtension.entitlements */,
 				9A77C73B256EC0B400B30BC6 /* ScheduleWidgetExtension.entitlements */,
 				16DBE6982569FCEE00B334A3 /* LetSwift.entitlements */,
@@ -252,6 +284,7 @@
 				16DBE62A2569EAD200B334A3 /* iOS */,
 				9A77C732256EC0B300B30BC6 /* ScheduleWidget */,
 				9A77C779256EC57300B30BC6 /* Upcoming1Widget */,
+				9AD49448256EE09900C9E5C4 /* Upcoming2Widget */,
 				9A77C72D256EC0B300B30BC6 /* Frameworks */,
 				16DBE6292569EAD200B334A3 /* Products */,
 			);
@@ -279,6 +312,7 @@
 				16DBE6282569EAD200B334A3 /* LetSwift.app */,
 				9A77C72C256EC0B300B30BC6 /* ScheduleWidgetExtension.appex */,
 				9A77C776256EC57300B30BC6 /* Upcoming1WidgetExtension.appex */,
+				9AD49445256EE09900C9E5C4 /* Upcoming2WidgetExtension.appex */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -453,6 +487,16 @@
 			path = Upcoming1Widget;
 			sourceTree = "<group>";
 		};
+		9AD49448256EE09900C9E5C4 /* Upcoming2Widget */ = {
+			isa = PBXGroup;
+			children = (
+				9AD49449256EE09900C9E5C4 /* Upcoming2Widget.swift */,
+				9AD4944B256EE09B00C9E5C4 /* Assets.xcassets */,
+				9AD4944D256EE09B00C9E5C4 /* Info.plist */,
+			);
+			path = Upcoming2Widget;
+			sourceTree = "<group>";
+		};
 		A5EC776D256BE2D60072E959 /* Supporting Views */ = {
 			isa = PBXGroup;
 			children = (
@@ -487,6 +531,7 @@
 			dependencies = (
 				9A77C739256EC0B400B30BC6 /* PBXTargetDependency */,
 				9A77C780256EC57400B30BC6 /* PBXTargetDependency */,
+				9AD4944F256EE09B00C9E5C4 /* PBXTargetDependency */,
 			);
 			name = LetSwift;
 			productName = "LetSwift (iOS)";
@@ -527,6 +572,23 @@
 			productReference = 9A77C776256EC57300B30BC6 /* Upcoming1WidgetExtension.appex */;
 			productType = "com.apple.product-type.app-extension";
 		};
+		9AD49444256EE09900C9E5C4 /* Upcoming2WidgetExtension */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 9AD49454256EE09B00C9E5C4 /* Build configuration list for PBXNativeTarget "Upcoming2WidgetExtension" */;
+			buildPhases = (
+				9AD49441256EE09900C9E5C4 /* Sources */,
+				9AD49442256EE09900C9E5C4 /* Frameworks */,
+				9AD49443256EE09900C9E5C4 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = Upcoming2WidgetExtension;
+			productName = Upcoming2WidgetExtension;
+			productReference = 9AD49445256EE09900C9E5C4 /* Upcoming2WidgetExtension.appex */;
+			productType = "com.apple.product-type.app-extension";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -543,6 +605,9 @@
 						CreatedOnToolsVersion = 12.0.1;
 					};
 					9A77C775256EC57300B30BC6 = {
+						CreatedOnToolsVersion = 12.0.1;
+					};
+					9AD49444256EE09900C9E5C4 = {
 						CreatedOnToolsVersion = 12.0.1;
 					};
 				};
@@ -563,6 +628,7 @@
 				16DBE6272569EAD200B334A3 /* LetSwift */,
 				9A77C72B256EC0B300B30BC6 /* ScheduleWidgetExtension */,
 				9A77C775256EC57300B30BC6 /* Upcoming1WidgetExtension */,
+				9AD49444256EE09900C9E5C4 /* Upcoming2WidgetExtension */,
 			);
 		};
 /* End PBXProject section */
@@ -594,6 +660,15 @@
 				9A77C78B256EC59300B30BC6 /* Event.json in Resources */,
 				9A77C790256EC6AB00B30BC6 /* Assets.xcassets in Resources */,
 				9A77C77D256EC57400B30BC6 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		9AD49443256EE09900C9E5C4 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9AD49468256EE10F00C9E5C4 /* Event.json in Resources */,
+				9AD4944C256EE09B00C9E5C4 /* Assets.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -676,6 +751,17 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		9AD49441256EE09900C9E5C4 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9AD4944A256EE09900C9E5C4 /* Upcoming2Widget.swift in Sources */,
+				9AD49463256EE10800C9E5C4 /* DateManager.swift in Sources */,
+				9AD4945E256EE10300C9E5C4 /* Event.swift in Sources */,
+				9AD49459256EE10100C9E5C4 /* Data.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -688,6 +774,11 @@
 			isa = PBXTargetDependency;
 			target = 9A77C775256EC57300B30BC6 /* Upcoming1WidgetExtension */;
 			targetProxy = 9A77C77F256EC57400B30BC6 /* PBXContainerItemProxy */;
+		};
+		9AD4944F256EE09B00C9E5C4 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 9AD49444256EE09900C9E5C4 /* Upcoming2WidgetExtension */;
+			targetProxy = 9AD4944E256EE09B00C9E5C4 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -962,6 +1053,57 @@
 			};
 			name = Release;
 		};
+		9AD49452256EE09B00C9E5C4 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
+				CODE_SIGN_ENTITLEMENTS = Upcoming2WidgetExtension.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = B3PWYBKFUK;
+				INFOPLIST_FILE = Upcoming2Widget/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = kr.codesquad.jk.letswift.Upcoming2Widget;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SUPPORTS_MACCATALYST = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		9AD49453256EE09B00C9E5C4 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
+				CODE_SIGN_ENTITLEMENTS = Upcoming2WidgetExtension.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = B3PWYBKFUK;
+				INFOPLIST_FILE = Upcoming2Widget/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = kr.codesquad.jk.letswift.Upcoming2Widget;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SUPPORTS_MACCATALYST = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -997,6 +1139,15 @@
 			buildConfigurations = (
 				9A77C783256EC57400B30BC6 /* Debug */,
 				9A77C784256EC57400B30BC6 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		9AD49454256EE09B00C9E5C4 /* Build configuration list for PBXNativeTarget "Upcoming2WidgetExtension" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				9AD49452256EE09B00C9E5C4 /* Debug */,
+				9AD49453256EE09B00C9E5C4 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/ScheduleWidget/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/ScheduleWidget/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ScheduleWidget/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/ScheduleWidget/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,98 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "83.5x83.5"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "scale" : "1x",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ScheduleWidget/Assets.xcassets/Contents.json
+++ b/ScheduleWidget/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ScheduleWidget/Assets.xcassets/WidgetBackground.colorset/Contents.json
+++ b/ScheduleWidget/Assets.xcassets/WidgetBackground.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ScheduleWidget/Info.plist
+++ b/ScheduleWidget/Info.plist
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>ScheduleWidget</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.widgetkit-extension</string>
+	</dict>
+</dict>
+</plist>

--- a/ScheduleWidget/ScheduleWidget.swift
+++ b/ScheduleWidget/ScheduleWidget.swift
@@ -1,0 +1,77 @@
+//
+//  ScheduleWidget.swift
+//  ScheduleWidget
+//
+//  Created by Doyeong Yeom on 2020/11/26.
+//
+
+import WidgetKit
+import SwiftUI
+
+struct Provider: TimelineProvider {
+    func placeholder(in context: Context) -> ScheduleWidgetEntry {
+        ScheduleWidgetEntry(date: Date())
+    }
+
+    func getSnapshot(in context: Context, completion: @escaping (ScheduleWidgetEntry) -> ()) {
+        let entry = ScheduleWidgetEntry(date: Date())
+        completion(entry)
+    }
+
+    func getTimeline(in context: Context, completion: @escaping (Timeline<Entry>) -> ()) {
+        let timeline = Timeline(entries: [ScheduleWidgetEntry(date: Date())], policy: .never)
+        completion(timeline)
+    }
+}
+
+struct ScheduleWidgetEntry: TimelineEntry {
+    var date: Date
+}
+
+struct ScheduleWidgetEntryView : View {
+    let events: [Event]
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Let's Swift Conference 2020")
+                .font(.headline)
+                .padding([.leading, .trailing], 10)
+            ForEach(events) { event in
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(event.title)
+                        .font(.footnote)
+                        .fontWeight(.medium)
+                        .padding([.leading, .trailing], 10)
+                    Text("\(event.date) \(event.dayOfTheWeek) \(event.time)")
+                        .font(.caption2)
+                        .foregroundColor(.secondary)
+                        .padding([.leading, .trailing], 10)
+                }
+                if events.last?.id != event.id {
+                    Divider()
+                }
+            }
+        }
+    }
+}
+
+@main
+struct ScheduleWidget: Widget {
+    let kind: String = "ScheduleWidget"
+
+    var body: some WidgetConfiguration {
+        StaticConfiguration(kind: kind, provider: Provider()) { entry in
+            ScheduleWidgetEntryView(events: events)
+        }
+        .configurationDisplayName("Let's Swift 2020")
+        .description("일정을 확인하시고 절대 놓치지 마세요!")
+        .supportedFamilies([.systemLarge])
+    }
+}
+
+struct ScheduleWidget_Previews: PreviewProvider {
+    static var previews: some View {
+        ScheduleWidgetEntryView(events: events)
+            .previewContext(WidgetPreviewContext(family: .systemLarge))
+    }
+}

--- a/ScheduleWidgetExtension.entitlements
+++ b/ScheduleWidgetExtension.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
+</dict>
+</plist>

--- a/Upcoming1Widget/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/Upcoming1Widget/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Upcoming1Widget/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/Upcoming1Widget/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,98 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "83.5x83.5"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "scale" : "1x",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Upcoming1Widget/Assets.xcassets/Contents.json
+++ b/Upcoming1Widget/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Upcoming1Widget/Assets.xcassets/WidgetBackground.colorset/Contents.json
+++ b/Upcoming1Widget/Assets.xcassets/WidgetBackground.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Upcoming1Widget/Info.plist
+++ b/Upcoming1Widget/Info.plist
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>Upcoming1Widget</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.widgetkit-extension</string>
+	</dict>
+</dict>
+</plist>

--- a/Upcoming1Widget/Upcoming1Widget.swift
+++ b/Upcoming1Widget/Upcoming1Widget.swift
@@ -1,0 +1,185 @@
+//
+//  UpComing1Widget.swift
+//  UpComing1Widget
+//
+//  Created by Doyeong Yeom on 2020/11/26.
+//
+
+import WidgetKit
+import SwiftUI
+
+struct Provider: TimelineProvider {
+    @Environment(\.widgetFamily) var family
+    
+    func placeholder(in context: Context) -> UpComing1WidgetEntry {
+        UpComing1WidgetEntry(date: Date(), event: events[0])
+    }
+
+    func getSnapshot(in context: Context, completion: @escaping (UpComing1WidgetEntry) -> ()) {
+        let entry = UpComing1WidgetEntry(date: Date(), event: events[0])
+        completion(entry)
+    }
+
+    func getTimeline(in context: Context, completion: @escaping (Timeline<Entry>) -> ()) {
+        let upcomingEvent: Event? = getUpcomingEvent()
+        
+        let entry: UpComing1WidgetEntry
+        let reloadPolicy: TimelineReloadPolicy
+        if let date = getReloadDate(upcomingEvent: upcomingEvent) {
+            entry = UpComing1WidgetEntry(date: date, event: upcomingEvent)
+            reloadPolicy = .atEnd
+        } else {
+            entry = UpComing1WidgetEntry(date: Date(), event: upcomingEvent)
+            reloadPolicy = .after(Calendar.current.date(byAdding: .day, value: 1, to: Date())!)
+        }
+        let timeline = Timeline(entries: [entry], policy: reloadPolicy)
+        completion(timeline)
+    }
+    
+    func getUpcomingEvent() -> Event? {
+        let dateManager = DateManager()
+        
+        for event in events {
+            guard let sessionTime = dateManager.stringDateConvert(date: event.date, time: event.time) else { continue }
+            if Date().timeIntervalSince1970 < sessionTime.end.timeIntervalSince1970 {
+                return event
+            }
+        }
+        return nil
+    }
+
+    func getReloadDate(upcomingEvent: Event?) -> Date? {
+        guard let event = upcomingEvent else { return nil }
+        let dateManager = DateManager()
+        return dateManager.stringDateConvert(date: event.date, time: event.time)?.end
+    }
+}
+
+struct UpComing1WidgetEntry: TimelineEntry {
+    var date: Date
+    var event: Event?
+}
+
+struct UpComing1SmallView: View {
+    let event: Event?
+    
+    var body: some View {
+        ZStack(alignment: .bottomLeading) {
+            Image("Placeholder")
+                .resizable()
+            VStack(alignment: .leading) {
+                Text(event?.title ?? "다음 이벤트가 없습니다")
+                    .font(.footnote)
+                    .fontWeight(.medium)
+                    .multilineTextAlignment(.leading)
+                    .padding([.leading, .trailing], 10)
+                Text([event?.date, event?.dayOfTheWeek].compactMap { $0 }.joined(separator: " "))
+                    .font(.caption)
+                    .multilineTextAlignment(.leading)
+                    .padding([.leading, .trailing], 10)
+                Text(event?.time ?? "")
+                    .font(.caption)
+                    .padding([.leading, .trailing, .bottom], 10)
+            }
+        }
+    }
+}
+
+struct UpComing1MediumView: View {
+    let event: Event?
+    
+    var body: some View {
+        GeometryReader { geometry in
+            HStack(alignment: .bottom) {
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(event?.title ?? "다음 이벤트가 없습니다")
+                        .font(.subheadline)
+                        .fontWeight(.medium)
+                        .multilineTextAlignment(.leading)
+                        .padding([.top, .leading, .trailing], 10)
+                    Text([event?.date, event?.dayOfTheWeek].compactMap { $0 }.joined(separator: " "))
+                        .font(.footnote)
+                        .multilineTextAlignment(.leading)
+                        .padding([.leading, .trailing], 10)
+                    Text(event?.time ?? "")
+                        .font(.footnote)
+                        .padding([.leading, .trailing], 10)
+                    Text(event?.description ?? "")
+                        .font(.caption)
+                        .padding([.leading, .trailing, .bottom], 10)
+                        .padding([.top], 5)
+                }
+                Spacer()
+                Image("Placeholder")
+                    .resizable().aspectRatio(contentMode: .fill)
+                    .frame(width: geometry.size.width * 0.25)
+                    .clipped()
+            }
+        }
+    }
+}
+
+struct UpComing1LargeView: View {
+    let event: Event?
+    
+    var body: some View {
+        GeometryReader { geometry in
+            VStack {
+                Image("Placeholder")
+                    .resizable().aspectRatio(contentMode: .fill)
+                    .frame(height: geometry.size.height * 0.5)
+                    .clipped()
+                VStack(alignment: .leading, spacing: 5) {
+                    Text(event?.title ?? "다음 이벤트가 없습니다")
+                        .font(.headline)
+                        .fontWeight(.semibold)
+                        .multilineTextAlignment(.leading)
+                        .padding([.leading, .trailing], 10)
+                    Text([event?.date, event?.dayOfTheWeek, event?.time].compactMap { $0 }.joined(separator: " "))
+                        .font(.subheadline)
+                        .padding([.leading, .trailing], 10)
+                    Text(event?.description ?? "")
+                        .font(.footnote)
+                        .multilineTextAlignment(.leading)
+                        .padding([.leading, .trailing, .bottom], 10)
+                        .padding([.top], 5)
+                        .truncationMode(.tail)
+                }
+            }
+        }
+    }
+}
+
+struct UpComing1WidgetEntryView: View {
+    @Environment(\.widgetFamily) var family
+    let event: Event?
+    
+    var body: some View {
+        if family == .systemSmall {
+            UpComing1SmallView(event: event)
+        } else if family == .systemMedium {
+            UpComing1MediumView(event: event)
+        } else if family == .systemLarge {
+            UpComing1LargeView(event: event)
+        }
+    }
+}
+
+@main
+struct UpComing1Widget: Widget {
+    let kind: String = "UpComing1Widget"
+
+    var body: some WidgetConfiguration {
+        StaticConfiguration(kind: kind, provider: Provider()) { entry in
+            UpComing1WidgetEntryView(event: entry.event)
+        }
+        .configurationDisplayName("Let's Swift 2020")
+        .description("다음 이벤트를 확인하시고 놓치지 마세요!")
+    }
+}
+
+struct UpComing1Widget_Previews: PreviewProvider {
+    static var previews: some View {
+        UpComing1WidgetEntryView(event: events[0])
+    }
+}

--- a/Upcoming1WidgetExtension.entitlements
+++ b/Upcoming1WidgetExtension.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
+</dict>
+</plist>

--- a/Upcoming2Widget/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/Upcoming2Widget/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Upcoming2Widget/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/Upcoming2Widget/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,98 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "83.5x83.5"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "scale" : "1x",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Upcoming2Widget/Assets.xcassets/Contents.json
+++ b/Upcoming2Widget/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Upcoming2Widget/Assets.xcassets/WidgetBackground.colorset/Contents.json
+++ b/Upcoming2Widget/Assets.xcassets/WidgetBackground.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Upcoming2Widget/Info.plist
+++ b/Upcoming2Widget/Info.plist
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>Upcoming2Widget</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.widgetkit-extension</string>
+	</dict>
+</dict>
+</plist>

--- a/Upcoming2Widget/Upcoming2Widget.swift
+++ b/Upcoming2Widget/Upcoming2Widget.swift
@@ -1,0 +1,179 @@
+//
+//  UpComing2Widget.swift
+//  UpComing2Widget
+//
+//  Created by Doyeong Yeom on 2020/11/26.
+//
+
+import WidgetKit
+import SwiftUI
+
+struct Provider: TimelineProvider {
+    @Environment(\.widgetFamily) var family
+    
+    func placeholder(in context: Context) -> UpComing2WidgetEntry {
+        UpComing2WidgetEntry(date: Date(), events: (events[0], events[1]))
+    }
+
+    func getSnapshot(in context: Context, completion: @escaping (UpComing2WidgetEntry) -> ()) {
+        let entry = UpComing2WidgetEntry(date: Date(), events: (events[0], events[1]))
+        completion(entry)
+    }
+
+    func getTimeline(in context: Context, completion: @escaping (Timeline<Entry>) -> ()) {
+        let upcomingEvents = getUpcomingEvents()
+        
+        let entry: UpComing2WidgetEntry
+        let reloadPolicy: TimelineReloadPolicy
+        if let sessionEndTime = getRefreshDate(upcomingEvents: upcomingEvents) {
+            entry = UpComing2WidgetEntry(date: sessionEndTime, events: upcomingEvents)
+            reloadPolicy = .atEnd
+        } else {
+            entry = UpComing2WidgetEntry(date: Date(), events: upcomingEvents)
+            reloadPolicy = .after(Calendar.current.date(byAdding: .day, value: 1, to: Date())!)
+        }
+        let timeline = Timeline(entries: [entry], policy: reloadPolicy)
+        completion(timeline)
+    }
+    
+    func getUpcomingEvents() -> (Event?, Event?) {
+        let dateManager = DateManager()
+        var upcomingEvents: (Event?, Event?) = (nil, nil)
+        
+        for event in events.enumerated() {
+            guard let sessionTime = dateManager.stringDateConvert(date: event.element.date, time: event.element.time) else { continue }
+            if Date().timeIntervalSince1970 < sessionTime.end.timeIntervalSince1970 {
+                if event.offset > events.count - 2 {
+                    upcomingEvents = (events[event.offset], nil)
+                } else {
+                    upcomingEvents = (events[event.offset], events[event.offset + 1])
+                }
+                break
+            }
+        }
+        return upcomingEvents
+    }
+    
+    func getRefreshDate(upcomingEvents: (Event?, Event?)) -> Date? {
+        guard let event = upcomingEvents.0 else { return nil }
+        let dateManager = DateManager()
+        return dateManager.stringDateConvert(date: event.date, time: event.time)?.end
+    }
+}
+
+struct UpComing2WidgetEntry: TimelineEntry {
+    var date: Date
+    let events: (Event?, Event?)
+}
+
+struct UpComing2SmallView: View {
+    let events: (Event?, Event?)
+    
+    var body: some View {
+        VStack(alignment: .leading) {
+            VStack(alignment: .leading) {
+                Text(events.0?.title ?? "다음 이벤트가 없습니다")
+                    .font(.footnote)
+                    .fontWeight(.medium)
+                    .multilineTextAlignment(.leading)
+                    .padding([.leading, .trailing], 10)
+                    .padding([.top], 5)
+                Text([events.0?.date, events.0?.dayOfTheWeek, events.0?.time].compactMap { $0 }.joined(separator: " "))
+                    .font(.caption)
+                    .multilineTextAlignment(.leading)
+                    .padding([.leading, .trailing], 10)
+                    .padding([.bottom], 5)
+            }
+            .frame(maxHeight: .infinity)
+            Divider()
+            VStack(alignment: .leading) {
+                Text(events.1?.title ?? "다음 이벤트가 없습니다")
+                    .font(.footnote)
+                    .fontWeight(.medium)
+                    .multilineTextAlignment(.leading)
+                    .padding([.leading, .trailing], 10)
+                    .padding([.top], 5)
+                Text([events.1?.date, events.1?.dayOfTheWeek, events.1?.time].compactMap { $0 }.joined(separator: " "))
+                    .font(.caption)
+                    .multilineTextAlignment(.leading)
+                    .padding([.leading, .trailing, .bottom], 10)
+                    .padding([.bottom], 5)
+            }
+            .frame(maxHeight: .infinity)
+        }
+    }
+}
+
+struct UpComing2MediumView: View {
+    let events: (Event?, Event?)
+    
+    var body: some View {
+        HStack(alignment: .center) {
+            VStack(alignment: .leading) {
+                Text(events.0?.title ?? "다음 이벤트가 없습니다")
+                    .font(.footnote)
+                    .fontWeight(.medium)
+                    .multilineTextAlignment(.leading)
+                    .padding([.leading, .trailing], 10)
+                Text([events.0?.date, events.0?.dayOfTheWeek].compactMap { $0 }.joined(separator: " "))
+                    .font(.caption)
+                    .multilineTextAlignment(.leading)
+                    .padding([.leading, .trailing], 10)
+                Text(events.0?.time ?? "")
+                    .font(.caption)
+                    .padding([.leading, .trailing, .bottom], 10)
+            }
+            .frame(maxWidth: .infinity)
+            Divider()
+            VStack(alignment: .leading) {
+                Text(events.1?.title ?? "다음 이벤트가 없습니다")
+                    .font(.footnote)
+                    .fontWeight(.medium)
+                    .multilineTextAlignment(.leading)
+                    .padding([.leading, .trailing], 10)
+                Text([events.1?.date, events.1?.dayOfTheWeek].compactMap { $0 }.joined(separator: " "))
+                    .font(.caption)
+                    .multilineTextAlignment(.leading)
+                    .padding([.leading, .trailing], 10)
+                Text(events.1?.time ?? "")
+                    .font(.caption)
+                    .padding([.leading, .trailing, .bottom], 10)
+            }
+            .frame(maxWidth: .infinity)
+        }
+    }
+}
+
+struct UpComing2WidgetEntryView: View {
+    @Environment(\.widgetFamily) var family
+    let events: (Event?, Event?)
+    
+    var body: some View {
+        if family == .systemSmall {
+            UpComing2SmallView(events: events)
+        } else if family == .systemMedium {
+            UpComing2MediumView(events: events)
+        }
+    }
+}
+
+@main
+struct UpComing2Widget: Widget {
+    let kind: String = "UpComing2Widget"
+
+    var body: some WidgetConfiguration {
+        StaticConfiguration(kind: kind, provider: Provider()) { entry in
+            UpComing2WidgetEntryView(events: entry.events)
+        }
+        .configurationDisplayName("Let's Swift 2020")
+        .description("다음 이벤트를 확인하시고 놓치지 마세요!")
+        .supportedFamilies([.systemSmall, .systemMedium])
+    }
+}
+
+struct UpComing2Widget_Previews: PreviewProvider {
+    static var previews: some View {
+        UpComing2WidgetEntryView(events: (events[0], events[1]))
+            .previewContext(WidgetPreviewContext(family: .systemSmall))
+    }
+}

--- a/Upcoming2WidgetExtension.entitlements
+++ b/Upcoming2WidgetExtension.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
WidgetKit Extension을 통해서 다가오는 이벤트, 스케쥴에 대한 구현을 하였습니다.

- Schedule Widget : 전체 일정을 노출하는 위젯 (only Large)
- Upcoming1Widget: 다음 일정을 1개 노출하는 위젯 (Small, Medium, Large)
- Upcoming2Widget: 다음 일정을 2개 노출하는 위젯 (Small, Medium)

UpcomingWidget의 타임라인은 다음 일정의 끝나는 시간 이후에 업데이트하는 것으로 구현했습니다.

범모님께서 주신 요구사항대로 우선 진행했는데, 디테일은 좀 잡아야할 것 같습니다!
혹시 수정이 필요한 사항 있으시면 언제든 피드백 부탁드립니다 👍 