### PR TITLE
Feat: 카드 설문 결과 차트 UI (using MockData)

### DIFF
--- a/2022/Playgrounds/ChartDataModel.swift
+++ b/2022/Playgrounds/ChartDataModel.swift
@@ -1,0 +1,34 @@
+//
+//  ChartDataModel.swift
+//  LetSwift
+//
+//  Created by 이가은 on 2022/11/01.
+//
+
+import SwiftUI
+
+struct TotalChartData: Identifiable{
+    let surveyId: Int
+    let answerId: Int
+    let count: Int
+    
+    var id: Int { answerId }
+}
+
+struct ChartData: Codable {
+    let totalCount: Int
+    let surveyList: [Survey]
+}
+
+struct Survey: Codable {
+    let surveyId: Int
+    let answerList: [Answer]
+}
+
+struct Answer: Codable, Identifiable {
+    let answerId: Int
+    let count: Int
+    
+    var id: Int { answerId }
+}
+

--- a/2022/Playgrounds/ChartMockData.json
+++ b/2022/Playgrounds/ChartMockData.json
@@ -1,0 +1,50 @@
+{
+    "totalCount" : 37,
+    "surveyList" : [
+        {
+            "surveyId": 1,
+            "answerList":  [
+                {"answerId": 1, "count": 10},
+                {"answerId": 2, "count": 7},
+                {"answerId": 3, "count": 10},
+                {"answerId": 4,  "count": 10}
+            ]
+        },
+        {
+            "surveyId" : 2,
+            "answerList":  [
+                {"answerId": 1, "count": 7},
+                {"answerId": 2, "count": 7},
+                {"answerId": 3, "count": 13},
+                {"answerId": 4,  "count": 10}
+            ]
+        },
+        {
+            "surveyId" : 3,
+            "answerList":  [
+                {"answerId": 1, "count": 10},
+                {"answerId": 2, "count": 7},
+                {"answerId": 3, "count": 10},
+                {"answerId": 4,  "count": 10}
+            ]
+        },
+        {
+            "surveyId" : 4,
+            "answerList":  [
+                {"answerId": 1, "count": 5},
+                {"answerId": 2, "count": 7},
+                {"answerId": 3, "count": 15},
+                {"answerId": 4,  "count": 10}
+            ]
+        },
+        {
+            "surveyId" : 5,
+            "answerList":  [
+                {"answerId": 1, "count":  10},
+                {"answerId": 2, "count": 7},
+                {"answerId": 3, "count": 10},
+                {"answerId": 4,  "count": 10}
+            ]
+        }
+    ]
+}

--- a/2022/Playgrounds/ChartViewModel.swift
+++ b/2022/Playgrounds/ChartViewModel.swift
@@ -1,0 +1,51 @@
+//
+//  ChartViewModel.swift
+//  LetSwift
+//
+//  Created by 이가은 on 2022/11/04.
+//
+
+import Foundation
+
+
+class ChartViewModel: ObservableObject {
+    @Published var chartData: ChartData?
+    @Published var totalChartDataList: [TotalChartData]?
+    
+    init() {
+        self.chartData = getChartMockData()
+        self.totalChartDataList = getTotalChartDataList()
+    }
+    
+    private func getChartMockData() -> ChartData? {
+        guard let path = Bundle.main.path(forResource: "ChartMockData", ofType: "json") else {
+            return nil
+        }
+        guard let jsonString = try? String(contentsOfFile: path) else {
+            return nil
+        }
+        let decoder = JSONDecoder()
+        let data = jsonString.data(using: .utf8)
+        guard let jsonData = data,
+              let chartData = try? decoder.decode(ChartData.self, from: jsonData) else {
+            return nil
+        }
+        return chartData
+    }
+    
+    private func getTotalChartDataList() -> [TotalChartData]? {
+        var totalChartDataList: [TotalChartData] = []
+        if chartData != nil {
+            for survey in self.chartData!.surveyList {
+                let surveyId = survey.surveyId
+                for answer in survey.answerList {
+                    let totalChartData = TotalChartData(surveyId: surveyId, answerId: answer.answerId, count: answer.count)
+                    totalChartDataList.append(totalChartData)
+                }
+            }
+            return totalChartDataList
+        } else {
+            return nil
+        }
+    }
+}

--- a/2022/Playgrounds/SurveyData.swift
+++ b/2022/Playgrounds/SurveyData.swift
@@ -1,0 +1,100 @@
+//
+//  SurveyData.swift
+//  LetSwift
+//
+//  Created by 이가은 on 2022/11/04.
+//
+
+import Foundation
+
+struct SurveyData {
+    var surveyId: Int
+    var question: String
+    var answer: [(answerId: Int, answer: String)]
+}
+
+struct TempChartData {
+    static let questionList = [
+        SurveyData(
+            surveyId: 1,
+            question: "Let’Swift 2022 컨퍼런스에 참여하게 된 주된 이유는 무엇인가요?",
+            answer: [
+                (answerId: 1, answer: "굿즈가 매력있어서"),
+                (answerId: 2, answer: "애플 워치 굿즈 받기 위해서"),
+                (answerId: 3, answer: "개발 지식을 습득하기 위하여"),
+                (answerId: 4, answer: "네트워킹을 위해서")
+            ]),
+        SurveyData(
+            surveyId: 2,
+            question: "어떤 계기로 인해 iOS 개발자로 진로를 결정하게 되셨나요?",
+            answer: [
+                (answerId: 1, answer: "iOS의 ui/ux가 좋아서"),
+                (answerId: 2, answer: "내가 아이폰을 사용하고 있기 때문에"),
+                (answerId: 3, answer: "iOS의 신기술들이 너무 좋아서"),
+                (answerId: 4, answer: "애플 생태계가 좋아서")
+            ]),
+        SurveyData(
+            surveyId: 3,
+            question: "평소 관심있는 주제가 무엇인가요?",
+            answer: [
+                (answerId: 1, answer: "HIG"),
+                (answerId: 2, answer: "새 기기 (m2칩, 맥북에어, 14프로 등)"),
+                (answerId: 3, answer: "wwdc.. 신기술.. 업데이트 공부"),
+                (answerId: 4, answer: "iOS의 컨퍼런스 및 소모임")
+            ]),
+        SurveyData(
+            surveyId: 4,
+            question: "개발할 때 제일 싫은 부분은?",
+            answer: [
+                (answerId: 1, answer: "디자인이 생각보다 안 이쁠 때"),
+                (answerId: 2, answer: "다양한 테스트 기기가 없을 때"),
+                (answerId: 3, answer: "최소 버전이 낮아서 쓰고 싶은 기술을 사용 못할 때"),
+                (answerId: 4, answer: "말이 안통해요 ^^")
+            ]),
+        SurveyData(
+            surveyId: 5,
+            question: "내 주변에 있었으면 하는 동료는?",
+            answer: [
+                (answerId: 1, answer: "디자인을 눈부시게 잘하는 동료"),
+                (answerId: 2, answer: "항상 최신 기기를 가지고 있어서 장단점 다 알려주는 동료"),
+                (answerId: 3, answer: "WWDC 같이 공부하는 동료"),
+                (answerId: 4, answer: "알잘딱깔센하게 알려주는 동료")
+            ])
+    ]
+    
+    enum CardCase: String {
+        case design = "🎨디자인왕"
+        case device = "📱기기왕"
+        case newTech = "💻신기술왕"
+        case conference = "🙆🏻‍♂️🙆🏻‍♀️소통왕"
+        case none
+    }
+    
+    static func getCardCase(answerId: Int) -> CardCase {
+        switch answerId {
+            case 1:
+                return CardCase.design
+            case 2:
+                return CardCase.device
+            case 3:
+                return CardCase.newTech
+            case 4:
+                return CardCase.conference
+            default:
+                return CardCase.none
+        }
+    }
+    
+    static func getQuestionText(surveyId: Int) -> String {
+        return TempChartData.questionList.first(where: {$0.surveyId == surveyId})?.question ?? "질문 없음"
+    }
+    static func getAnswerText(surveyId: Int, answerId: Int) -> String {
+        if let surveyData = TempChartData.questionList.first(where: {$0.surveyId == surveyId}),
+           let answerText = surveyData.answer.first(where: { $0.answerId == answerId }) {
+            return answerText.answer
+        } else {
+            return "답변 없음"
+        }
+    }
+    
+}

--- a/App/LetSwiftApp.swift
+++ b/App/LetSwiftApp.swift
@@ -12,7 +12,7 @@ import UserNotifications
 struct LetSwiftApp: App {
     var body: some Scene {
         WindowGroup {
-            ChartView()
+            MainView()
                 .accentColor(.themePrimary)
                 .onAppear {
                     UNUserNotificationCenter.requestLetSwiftNotification()

--- a/App/LetSwiftApp.swift
+++ b/App/LetSwiftApp.swift
@@ -12,7 +12,7 @@ import UserNotifications
 struct LetSwiftApp: App {
     var body: some Scene {
         WindowGroup {
-            MainView()
+            ChartView()
                 .accentColor(.themePrimary)
                 .onAppear {
                     UNUserNotificationCenter.requestLetSwiftNotification()

--- a/LetSwift.xcodeproj/project.pbxproj
+++ b/LetSwift.xcodeproj/project.pbxproj
@@ -155,6 +155,11 @@
 		A5EC7768256BD23D0072E959 /* People.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5EC7767256BD23D0072E959 /* People.swift */; };
 		A5EC776F256BE2FB0072E959 /* GridView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5EC776E256BE2FB0072E959 /* GridView.swift */; };
 		A5EC7773256BE3730072E959 /* PeopleGroupedByRoleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5EC7772256BE3730072E959 /* PeopleGroupedByRoleView.swift */; };
+		CC1E753E291512820016092D /* ChartMockData.json in Resources */ = {isa = PBXBuildFile; fileRef = CC1E753D291512820016092D /* ChartMockData.json */; };
+		CC2DCDC7291514FC00419AFC /* ChartViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC2DCDC6291514FC00419AFC /* ChartViewModel.swift */; };
+		CC2DCDC929151F8700419AFC /* SurveyData.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC2DCDC829151F8700419AFC /* SurveyData.swift */; };
+		CCEF707829114AC300239EC9 /* ChartView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCEF707729114AC300239EC9 /* ChartView.swift */; };
+		CCFF977F29114CEF00BC5FD3 /* ChartDataModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCFF977E29114CEF00BC5FD3 /* ChartDataModel.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -309,6 +314,11 @@
 		A5EC7767256BD23D0072E959 /* People.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = People.swift; sourceTree = "<group>"; };
 		A5EC776E256BE2FB0072E959 /* GridView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GridView.swift; sourceTree = "<group>"; };
 		A5EC7772256BE3730072E959 /* PeopleGroupedByRoleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeopleGroupedByRoleView.swift; sourceTree = "<group>"; };
+		CC1E753D291512820016092D /* ChartMockData.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = ChartMockData.json; sourceTree = "<group>"; };
+		CC2DCDC6291514FC00419AFC /* ChartViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChartViewModel.swift; sourceTree = "<group>"; };
+		CC2DCDC829151F8700419AFC /* SurveyData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurveyData.swift; sourceTree = "<group>"; };
+		CCEF707729114AC300239EC9 /* ChartView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ChartView.swift; path = ../../../../Downloads/ChartView.swift; sourceTree = "<group>"; };
+		CCFF977E29114CEF00BC5FD3 /* ChartDataModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChartDataModel.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -659,6 +669,11 @@
 		6FD7CDAB290C030B002CF140 /* Playgrounds */ = {
 			isa = PBXGroup;
 			children = (
+				CCEF707729114AC300239EC9 /* ChartView.swift */,
+				CC2DCDC6291514FC00419AFC /* ChartViewModel.swift */,
+				CCFF977E29114CEF00BC5FD3 /* ChartDataModel.swift */,
+				CC2DCDC829151F8700419AFC /* SurveyData.swift */,
+				CC1E753D291512820016092D /* ChartMockData.json */,
 			);
 			path = Playgrounds;
 			sourceTree = "<group>";
@@ -889,6 +904,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				60E17672256D509B0068B3F4 /* Event.json in Resources */,
+				CC1E753E291512820016092D /* ChartMockData.json in Resources */,
 				167BE5262573A1CB00C6681A /* let.usdz in Resources */,
 				16DBE6382569EAD200B334A3 /* Assets.xcassets in Resources */,
 				167BE51925738C8000C6681A /* Timeline.xcassets in Resources */,
@@ -985,6 +1001,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CC2DCDC7291514FC00419AFC /* ChartViewModel.swift in Sources */,
+				CCFF977F29114CEF00BC5FD3 /* ChartDataModel.swift in Sources */,
 				1624BF0C256B753500634E29 /* CGFloat.swift in Sources */,
 				16DBE6CB256A2EC800B334A3 /* Application.swift in Sources */,
 				167BE5C02574A73800C6681A /* AddPassButton.swift in Sources */,
@@ -995,6 +1013,8 @@
 				16984E7B256A33AE0011C872 /* CalendarManager.swift in Sources */,
 				60E1766A256D4FBE0068B3F4 /* Event.swift in Sources */,
 				16DBE6A8256A279B00B334A3 /* ScheduleView.swift in Sources */,
+				CCEF707829114AC300239EC9 /* ChartView.swift in Sources */,
+				CC2DCDC929151F8700419AFC /* SurveyData.swift in Sources */,
 				16984E79256A33AC0011C872 /* GlobalAction.swift in Sources */,
 				A5EC7773256BE3730072E959 /* PeopleGroupedByRoleView.swift in Sources */,
 				6054DA7D256A9DBF00A49BD4 /* DateManager.swift in Sources */,


### PR DESCRIPTION
카드 설문 결과 차트 UI를 구현했습니다.
지금은 MockData Json을 사용해서 구현되어 있는데 백엔드 개발자분과 조율 후 실데이터로 구현하도록 변경하겠습니다 :)

<table> 
        <tr>
           <td><img src="https://user-images.githubusercontent.com/82457928/200091976-b88a594d-5519-4ad5-9192-7734e9902fc4.png" width="350" ></td>
           <td><img src= "https://user-images.githubusercontent.com/82457928/200091972-9566f92c-485f-4737-a514-c3ad591cfae7.png" width="350" ></td>
           <td><img src="https://user-images.githubusercontent.com/82457928/200091969-b053acb6-2e04-4056-bf65-f9b70d952f2a.png" width="350" ></td>
        </tr>