### PR TITLE
Badge View & Question View 화면 추가

### DIFF
--- a/2022/Badges/Components/BackgroundView.swift
+++ b/2022/Badges/Components/BackgroundView.swift
@@ -1,0 +1,17 @@
+//
+//  BackgroundView.swift
+//  LetSwift
+//
+//  Created by Son on 2022/11/16.
+//
+
+import SwiftUI
+
+struct BackgroundView : View {
+    var body: some View {
+        Rectangle()
+            .fill(LinearGradient.gradientOrange.opacity(0.45))
+            .cornerRadius(5)
+            .shadow(color: .black.opacity(0.4), radius: 5, x: 4, y: 4)
+    }
+}

--- a/2022/Badges/Components/BadgeInfoView.swift
+++ b/2022/Badges/Components/BadgeInfoView.swift
@@ -1,0 +1,28 @@
+//
+//  BadgeInfoView.swift
+//  LetSwift
+//
+//  Created by Son on 2022/11/16.
+//
+
+import SwiftUI
+
+struct BadgeInfoView : View {
+    let titleText = "세션에 참여한 후, 6개 이상의 문제를 풀어보세요 !"
+    
+    var body: some View {
+        HStack(alignment: .center, spacing: 14.0) {
+            Image("tempImage")
+                .resizable()
+                .frame(width: 132.0, height: 132.0)
+                
+            Text(titleText)
+                .font(.bodyRegular)
+                .foregroundColor(.white)
+                .padding(.horizontal, 31.0)
+            
+            Spacer()
+        }
+        .padding(.horizontal, 35.0)
+    }
+}

--- a/2022/Badges/Components/BadgeInfoView.swift
+++ b/2022/Badges/Components/BadgeInfoView.swift
@@ -14,6 +14,7 @@ struct BadgeInfoView : View {
         HStack(alignment: .center, spacing: 14.0) {
             Image("tempImage")
                 .resizable()
+                .cornerRadius(12)
                 .frame(width: 132.0, height: 132.0)
                 
             Text(titleText)

--- a/2022/Badges/Components/BadgeQuestionView.swift
+++ b/2022/Badges/Components/BadgeQuestionView.swift
@@ -1,0 +1,28 @@
+//
+//  BadgeQuestionView.swift
+//  LetSwift
+//
+//  Created by Son on 2022/11/16.
+//
+
+import SwiftUI
+
+struct BadgeQuestionView: View {
+    var question : QuestionData
+    init(question: QuestionData) {
+        self.question = question
+    }
+    
+    var body: some View {
+        HStack(alignment: .center, spacing: 32.0) {
+            Spacer()
+            Text(question.question)
+                .font(.bodyRegular)
+                .foregroundColor(.white)
+                .padding(.all, 20.0)
+            Spacer()
+        }
+        .background(BackgroundView())
+        .padding(.horizontal, 27.0)
+    }
+}

--- a/2022/Badges/Components/BadgeQuestionView.swift
+++ b/2022/Badges/Components/BadgeQuestionView.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 struct BadgeQuestionView: View {
+    
     var question : QuestionData
     init(question: QuestionData) {
         self.question = question
@@ -16,10 +17,12 @@ struct BadgeQuestionView: View {
     var body: some View {
         HStack(alignment: .center, spacing: 32.0) {
             Spacer()
-            Text(question.question)
-                .font(.bodyRegular)
-                .foregroundColor(.white)
-                .padding(.all, 20.0)
+            NavigationLink(destination: QuestionView(data: question)) {
+                Text(question.question)
+                    .font(.bodyRegular)
+                    .foregroundColor(.white)
+                    .padding(.all, 20.0)
+            }
             Spacer()
         }
         .background(BackgroundView())

--- a/2022/Badges/Components/QuestionInfoView.swift
+++ b/2022/Badges/Components/QuestionInfoView.swift
@@ -1,0 +1,69 @@
+//
+//  QuestionInfoView.swift
+//  LetSwift
+//
+//  Created by Son on 2022/11/18.
+//
+
+import SwiftUI
+
+struct QuestionInfoView: View {
+    @State var userAnswer: String = ""
+    @State var isCorrect: Bool = false
+    
+    var data: QuestionData
+    init(data: QuestionData) {
+        self.data = data
+        self.isCorrect = data.isCorrect
+    }
+    
+    func checkAnswer() {
+        isCorrect = (data.answer == userAnswer)
+    }
+    
+    @ViewBuilder func roundBox() -> some View {
+        Rectangle()
+            .fill(.white)
+            .cornerRadius(5)
+    }
+    
+    var body: some View {
+        VStack (alignment: .leading, spacing: 0) {
+            Text(data.question)
+                .font(.bodyRegular)
+                .foregroundColor(.white)
+                .padding(.horizontal, 4)
+                .padding(.vertical, 16)
+            
+            HStack(alignment: .top) {
+                if #available(iOS 16.0, *) {
+                    TextField("답을 입력해주세요", text: $userAnswer, axis: .vertical)
+                        .frame(height: 70, alignment: .topLeading)
+                        .lineLimit(3)
+                        .padding(20)
+                } else {
+                    TextField("답을 입력해주세요", text: $userAnswer)
+                        .frame(height: 70, alignment: .topLeading)
+                        .lineLimit(3)
+                        .font(.bodyRegular)
+                        .padding(20)
+                }
+            }
+            .frame(height: 105)
+            .background(roundBox())
+            
+            Spacer().frame(height: 16)
+            
+            Button {
+                self.checkAnswer()
+            } label: {
+                Text("답 제출하기")
+                    .foregroundColor(.white)
+            }
+            .frame(height: 51, alignment: .center)
+            .frame(maxWidth: .infinity)
+            .background(BackgroundView())
+        }
+        .padding(.horizontal, 5)
+    }
+}

--- a/2022/Badges/Components/QuestionSessionView.swift
+++ b/2022/Badges/Components/QuestionSessionView.swift
@@ -1,0 +1,60 @@
+//
+//  QuestionSessionView.swift
+//  LetSwift
+//
+//  Created by Son on 2022/11/18.
+//
+
+import SwiftUI
+
+struct QuestionSessionView: View {
+    var session: QuestionSessionData
+    init(session: QuestionSessionData) {
+        self.session = session
+    }
+    
+    var body: some View {
+        VStack(alignment: .leading) {
+            Text("관련 세션")
+                .font(.bodyBold)
+                .foregroundColor(.white)
+            HStack(alignment: .top) {
+                Image("tempImage")
+                    .resizable()
+                    .frame(width: 70, height: 70)
+                    .cornerRadius(8)
+                VStack(alignment: .leading) {
+                    Text(session.datetime)
+                        .font(.bodyRegular)
+                        .foregroundColor(.white)
+                    Spacer().frame(height: 2)
+                    
+                    Text(session.title)
+                        .font(.bodyBold)
+                        .foregroundColor(.white)
+                    
+                    Spacer().frame(height: 7)
+                        
+                    Text(session.contents)
+                        .font(.subheadRegular)
+                        .foregroundColor(.textGray)
+                    Spacer().frame(height: 21)
+                    Button {
+                        //TODO : NAVIGATE TO SESSION VIEW
+                    } label: {
+                        Text("더보기")
+                            .font(.bodyRegular)
+                            .foregroundColor(.white)
+                    }
+                    .frame(width: 100, height: 35, alignment: .center)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 17.5)
+                            .stroke(.white)
+                    )
+                    
+                    
+                }.padding(.horizontal, 30)
+            }.padding(.vertical, 18)
+        }
+    }
+}

--- a/2022/Badges/Components/UnderLineView.swift
+++ b/2022/Badges/Components/UnderLineView.swift
@@ -7,7 +7,6 @@
 
 import SwiftUI
 
-
 struct UnderLineView : View {
     var body: some View {
         VStack {

--- a/2022/Badges/Components/UnderLineView.swift
+++ b/2022/Badges/Components/UnderLineView.swift
@@ -1,0 +1,20 @@
+//
+//  UndergroundView.swift
+//  LetSwift
+//
+//  Created by Son on 2022/11/17.
+//
+
+import SwiftUI
+
+
+struct UnderLineView : View {
+    var body: some View {
+        VStack {
+            Spacer()
+            Rectangle()
+                .fill(LinearGradient.gradientOrange.opacity(0.45))
+                .frame(width: 73, height: 3)
+        }
+    }
+}

--- a/2022/Badges/Data/QuestionData.swift
+++ b/2022/Badges/Data/QuestionData.swift
@@ -1,0 +1,40 @@
+//
+//  QuestionData.swift
+//  LetSwift
+//
+//  Created by Son on 2022/11/18.
+//
+
+import Foundation
+
+struct QuestionData {
+    var question: String
+    var answer: String
+    
+    var session: QuestionSessionData
+}
+
+struct QuestionSessionData {
+    var profile: String
+    var datetime: String
+    var title: String
+    var contents: String
+}
+
+extension QuestionData {
+    static var dummy : [QuestionData] = [
+        QuestionData(question: "우리 행사이름 ?", answer: "letswift", session: .dummy),
+        QuestionData(question: "multiline text test\nmultiline text test\nmultiline text test", answer: "lorem ipsum", session: .dummy),
+        QuestionData(question: "swiftUI", answer: "반갑습니다", session: .dummy),
+        QuestionData(question: "넓게넓게넓게쓰기넓게넓게넓게쓰기넓게넓게넓게쓰기넓게넓게넓게쓰기", answer: "반갑습니다", session: .dummy)
+    ]
+}
+
+extension QuestionSessionData {
+    static var dummy : QuestionSessionData = QuestionSessionData(
+        profile: "손재구",
+        datetime: "11:00 - 12:00",
+        title: "letswift",
+        contents: "letswift 행사 더미데이터 입니다"
+    )
+}

--- a/2022/Badges/Data/QuestionData.swift
+++ b/2022/Badges/Data/QuestionData.swift
@@ -10,6 +10,7 @@ import Foundation
 struct QuestionData {
     var question: String
     var answer: String
+    var isCorrect: Bool = false
     
     var session: QuestionSessionData
 }

--- a/2022/Badges/QuestionView.swift
+++ b/2022/Badges/QuestionView.swift
@@ -8,13 +8,40 @@
 import SwiftUI
 
 struct QuestionView: View {
+    @Environment(\.presentationMode) var presentationMode: Binding<PresentationMode>
+    var data: QuestionData
+    init(data: QuestionData) {
+        self.data = data
+    }
+    
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        VStack(alignment: .leading) {
+            Button {
+                self.presentationMode.wrappedValue.dismiss()
+            } label: {
+                Text("X")
+                    .foregroundColor(.white)
+            }
+            Text("Q.")
+                .font(.title3Bold)
+                .foregroundColor(.white)
+                .padding(.horizontal, 9.0)
+                .padding(.top, 19.0)
+            QuestionInfoView(data: data)
+            Spacer()
+                .frame(height: 53.0)
+            QuestionSessionView(session: data.session)
+            Spacer()
+        }
+        .navigationBarBackButtonHidden(true)
+        .padding(.horizontal, 29.0)
+        .background(Color.backgroundBlack)
     }
 }
 
+
 struct QuestionView_Previews: PreviewProvider {
     static var previews: some View {
-        QuestionView()
+        QuestionView(data: QuestionData.dummy.first!)
     }
 }

--- a/2022/Badges/QuestionView.swift
+++ b/2022/Badges/QuestionView.swift
@@ -1,0 +1,20 @@
+//
+//  QuestionView.swift
+//  LetSwift
+//
+//  Created by Son on 2022/11/18.
+//
+
+import SwiftUI
+
+struct QuestionView: View {
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}
+
+struct QuestionView_Previews: PreviewProvider {
+    static var previews: some View {
+        QuestionView()
+    }
+}

--- a/App/View/TabNavigationView.swift
+++ b/App/View/TabNavigationView.swift
@@ -42,7 +42,7 @@ extension TabNavigationView {
         var presentingView: some View {
             switch self {
             case .sessions: return AnyView(HomeView())
-            case .badges: return AnyView(ScheduleView())
+            case .badges: return AnyView(BadgeView())
             case .playgrounds:
                 return AnyView(GuestBookContainerView().environmentObject(GuestBookEnviromentOjb()))
             case .settings: return AnyView(SettingMainView())

--- a/BadgeView.swift
+++ b/BadgeView.swift
@@ -1,0 +1,20 @@
+//
+//  BadgeView.swift
+//  LetSwift
+//
+//  Created by Son on 2022/11/15.
+//
+
+import SwiftUI
+
+struct BadgeView: View {
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}
+
+struct BadgeView_Previews: PreviewProvider {
+    static var previews: some View {
+        BadgeView()
+    }
+}

--- a/BadgeView.swift
+++ b/BadgeView.swift
@@ -8,10 +8,55 @@
 import SwiftUI
 
 struct BadgeView: View {
+    var questions = QuestionData.dummy
+    @State var filter = false
+    
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        NavigationView {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 28.0) {
+                    Text("뱃지받지")
+                        .font(.title3Bold)
+                        .foregroundColor(.white)
+                        .padding(.leading, 39.0)
+                    BadgeInfoView()
+                    HStack(alignment: .center, spacing: 37.0)  {
+                        Text("0 / 6")
+                            .font(.bodyRegular)
+                            .foregroundColor(.white)
+                        Spacer()
+                        Button {
+                            self.filter = false
+                        } label: {
+                            Text("전체 보기")
+                                .foregroundColor(.white)
+                        }
+                        .frame(width: 82, height: 32, alignment: .center)
+                        .cornerRadius(5)
+                        .background(BackgroundView())
+                        
+                        Button {
+                            self.filter = true
+                        } label: {
+                            Text("미완료")
+                                .foregroundColor(.white)
+                        }
+                        .frame(width: 82, height: 32, alignment: .center)
+                        .cornerRadius(5)
+                        .background(UnderLineView())
+                    }
+                    .padding(.horizontal, 41.0)
+                    ForEach(0 ..< questions.count, id: \.self) { idx in
+                        BadgeQuestionView(question: questions[idx])
+                    }
+                }
+            }.background(Color.backgroundBlack)
+        }
     }
 }
+
+
+
 
 struct BadgeView_Previews: PreviewProvider {
     static var previews: some View {


### PR DESCRIPTION
**BadgeView**
- Badge View 화면 생성 및 Hi-fi에 맞춰 적용
- 화면 Component 구성 및 분할
- 세션 더미데이터 추가 
- 문제 관련 데이터 구성

<img width="340" alt="스크린샷 2022-11-18 오후 6 44 53" src="https://user-images.githubusercontent.com/32858909/202671834-d50973a9-4624-4b75-9bbf-8f171abb0bb6.png">

**QuestionView**
- Badge View 화면 생성 및 Hi-fi에 맞춰 적용
- 정답 관련 상태 처리 진행중

<img width="346" alt="스크린샷 2022-11-18 오후 6 45 04" src="https://user-images.githubusercontent.com/32858909/202671853-dc09cde0-e214-474a-b2b4-ae455fe6fb35.png">

**ETC**
- MainTab 두 번째 BadgeView로 변경

**TODO**
- API 연결
- 정답 관련 상태 처리
- filter 관련 상태 처리
- particle animation
- 세션 뷰 연결하기