### PR TITLE
[feat] NearbyInteraction, MultipeerConnectivity를 이용한 사용자 찾기 및 거리 계산

### DIFF
--- a/2022/Playgrounds/CheeringCard/PeerConnection/Model/Peer.swift
+++ b/2022/Playgrounds/CheeringCard/PeerConnection/Model/Peer.swift
@@ -1,0 +1,19 @@
+//
+//  Peer.swift
+//  LetSwift
+//
+//  Created by Noah on 2022/11/24.
+//
+
+import Foundation
+import MultipeerConnectivity
+
+struct Peer: Identifiable {
+    let id: MCPeerID
+    let displayName: String
+    
+    init(id: MCPeerID) {
+        self.id = id
+        self.displayName = id.displayName
+    }
+}

--- a/2022/Playgrounds/CheeringCard/PeerConnection/MultipeerConnectivityManager.swift
+++ b/2022/Playgrounds/CheeringCard/PeerConnection/MultipeerConnectivityManager.swift
@@ -63,6 +63,15 @@ final class MultipeerConnectivityManager: NSObject {
             timeout: TimeInterval(20)
         )
     }
+    
+    /// peer에게 데이터를 전송합니다.
+    func send(with data: Data, to peerID: MCPeerID) {
+        do {
+            try self.session.send(data, toPeers: [peerID], with: .reliable)
+        } catch let error {
+            print("🧨 \(error.localizedDescription)")
+        }
+    }
 }
 
 private extension MultipeerConnectivityManager {
@@ -146,7 +155,6 @@ extension MultipeerConnectivityManager: MCSessionDelegate {
             self.peerConnected.send(peerID)
         case .notConnected:
             self.peerNotConnected.send(peerID)
-            print("Not connected: \(peerID.displayName)")
         case .connecting:
             print("Connecting to: \(peerID.displayName)")
         @unknown default:

--- a/2022/Playgrounds/CheeringCard/PeerConnection/MultipeerConnectivityManager.swift
+++ b/2022/Playgrounds/CheeringCard/PeerConnection/MultipeerConnectivityManager.swift
@@ -1,0 +1,83 @@
+//
+//  MultipeerConnectivityManager.swift
+//  LetSwift
+//
+//  Created by Noah on 2022/11/24.
+//
+
+import Combine
+import Foundation
+import MultipeerConnectivity
+
+final class MultipeerConnectivityManager: NSObject {
+    // MARK: - properties
+    
+    /// 응원카드의 타입이 같은 사용자와의 연결을 위한 필드입니다.
+    private let cheeringCardType: String
+    private let session: MCSession
+    private let localPeerId: MCPeerID
+    @Published var receivedPeerID: MCPeerID?
+    private let nearbyServiceBrowser: MCNearbyServiceBrowser
+    private let nearbyServiceAdvertiser: MCNearbyServiceAdvertiser
+    let peerConnected: PassthroughSubject<MCPeerID, Never>
+    let peerNotConnected: PassthroughSubject<MCPeerID, Never>
+    let peerLosted: PassthroughSubject<MCPeerID, Never>
+    let dataReceived: PassthroughSubject<(MCPeerID, Data), Never>
+    
+    override init() {
+        let serviceType = "letswift"
+        self.cheeringCardType = MultipeerConnectivityManager.getCheeringCardType()
+        
+        self.localPeerId = MCPeerID(
+            displayName: MultipeerConnectivityManager.getUserName()
+        )
+        self.session = MCSession(
+            peer: self.localPeerId,
+            securityIdentity: nil,
+            encryptionPreference: .none
+        )
+        self.nearbyServiceAdvertiser = MCNearbyServiceAdvertiser(
+            peer: self.localPeerId,
+            discoveryInfo: [self.cheeringCardType: self.cheeringCardType],
+            serviceType: serviceType
+        )
+        self.nearbyServiceBrowser = MCNearbyServiceBrowser(
+            peer: self.localPeerId,
+            serviceType: serviceType
+        )
+        self.peerConnected = PassthroughSubject()
+        self.peerNotConnected = PassthroughSubject()
+        self.peerLosted = PassthroughSubject()
+        self.dataReceived = PassthroughSubject()
+        super.init()
+        self.setDelegation()
+    }
+}
+
+private extension MultipeerConnectivityManager {
+    // MARK: - private func
+    
+    func setDelegation() {
+        self.session.delegate = self
+        self.nearbyServiceAdvertiser.delegate = self
+        self.nearbyServiceBrowser.delegate = self
+    }
+    
+    static func getCheeringCardType() -> String {
+        guard let cheeringCardCategory = SharedPreference.shared.cheeringCard?.category
+        else {
+            return "none"
+        }
+        
+        return cheeringCardCategory.utf8EncodedString()
+    }
+    
+    static func getUserName() -> String {
+        guard let userName = SharedPreference.shared.cheeringCard?.name
+        else {
+            return UIDevice.current.name
+        }
+        
+        return userName
+    }
+}

--- a/2022/Playgrounds/CheeringCard/PeerConnection/MultipeerConnectivityManager.swift
+++ b/2022/Playgrounds/CheeringCard/PeerConnection/MultipeerConnectivityManager.swift
@@ -52,6 +52,17 @@ final class MultipeerConnectivityManager: NSObject {
         super.init()
         self.setDelegation()
     }
+    
+    /// peer를 session에 초대합니다.
+    func invite(to peerID: MCPeerID)  {
+        let context = peerID.displayName.data(using: .utf8)
+        self.nearbyServiceBrowser.invitePeer(
+            peerID,
+            to: self.session,
+            withContext: context,
+            timeout: TimeInterval(20)
+        )
+    }
 }
 
 private extension MultipeerConnectivityManager {

--- a/2022/Playgrounds/CheeringCard/PeerConnection/MultipeerConnectivityManager.swift
+++ b/2022/Playgrounds/CheeringCard/PeerConnection/MultipeerConnectivityManager.swift
@@ -72,6 +72,23 @@ final class MultipeerConnectivityManager: NSObject {
             print("🧨 \(error.localizedDescription)")
         }
     }
+    
+    // MARK: - func
+    
+    func startMultiPeerConnectionManager() {
+        self.nearbyServiceAdvertiser.startAdvertisingPeer()
+        self.nearbyServiceBrowser.startBrowsingForPeers()
+    }
+    
+    func stopMultiPeerConnectionManager() {
+        self.nearbyServiceAdvertiser.stopAdvertisingPeer()
+        self.nearbyServiceBrowser.stopBrowsingForPeers()
+    }
+    
+    /// MCSession의 연결을 해제합니다.
+    func disconnectSession() {
+        self.session.disconnect()
+    }
 }
 
 private extension MultipeerConnectivityManager {
@@ -155,6 +172,7 @@ extension MultipeerConnectivityManager: MCSessionDelegate {
             self.peerConnected.send(peerID)
         case .notConnected:
             self.peerNotConnected.send(peerID)
+            print("Not connected: \(peerID.displayName)")
         case .connecting:
             print("Connecting to: \(peerID.displayName)")
         @unknown default:

--- a/2022/Playgrounds/CheeringCard/PeerConnection/NearbyInteractionManager.swift
+++ b/2022/Playgrounds/CheeringCard/PeerConnection/NearbyInteractionManager.swift
@@ -27,6 +27,10 @@ final class NearbyInteractionManager: NSObject {
     
     // MARK: - func
     
+    func setPeerDiscoveryToken(_ discoveryToken: NIDiscoveryToken) {
+        self.peerDiscoveryToken = discoveryToken
+    }
+    
     /// NISession을 initiate합니다.
     func initiateNearbySession() {
         guard let peerDiscoveryToken

--- a/2022/Playgrounds/CheeringCard/PeerConnection/NearbyInteractionManager.swift
+++ b/2022/Playgrounds/CheeringCard/PeerConnection/NearbyInteractionManager.swift
@@ -54,7 +54,95 @@ final class NearbyInteractionManager: NSObject {
 
 private extension NearbyInteractionManager {
     // MARK: - private func
+    
     func setNearbyInteractionSessionDelegate() {
         self.session?.delegate = self
+    }
+}
+
+extension NearbyInteractionManager: NISessionDelegate {
+    func session(_ session: NISession, didUpdate nearbyObjects: [NINearbyObject]) {
+        guard let peerDiscoveryToken
+        else {
+            fatalError("don't have peer token")
+        }
+        
+        let peerObject = nearbyObjects.first { (object) -> Bool in
+            return object.discoveryToken == peerDiscoveryToken
+        }
+        
+        guard let updatedNearbyObject = peerObject
+        else {
+            return
+        }
+        
+        self.updatedNearbyObject = updatedNearbyObject
+    }
+    
+    func session(_ session: NISession, didRemove nearbyObjects: [NINearbyObject], reason: NINearbyObject.RemovalReason) {
+        guard let peerDiscoveryToken =  self.peerDiscoveryToken
+        else {
+            fatalError("don't have peer token")
+        }
+        
+        let peerObject = nearbyObjects.first { (object) -> Bool in
+            return object.discoveryToken == peerDiscoveryToken
+        }
+        
+        if peerObject == nil {
+            return
+        }
+        
+        switch reason {
+        case .peerEnded:
+            self.startNearbyInteractionSession()
+        case .timeout:
+            if let config = session.configuration {
+                session.run(config)
+            }
+        default:
+            fatalError("Unknown and unhandled NINearbyObject.RemovalReason")
+        }
+    }
+    
+    func sessionWasSuspended(_ session: NISession) {
+        print("Session suspended")
+    }
+    
+    func sessionSuspensionEnded(_ session: NISession) {
+        if let configuration = self.session?.configuration {
+            session.run(configuration)
+        } else {
+            self.startNearbyInteractionSession()
+        }
+    }
+    
+    func session(_ session: NISession, didInvalidateWith error: Error) {
+        let scenes = UIApplication.shared.connectedScenes
+        let windowScene = scenes.first as? UIWindowScene
+        
+        guard let window = windowScene?.windows.first
+        else { return }
+        
+        /// 근처 상호작용 권한이 설정되어있지 않은 경우
+        if case NIError.userDidNotAllow = error {
+            let accessAlertController = UIAlertController(title: "권한 요청",
+                                                          message: """
+                                                    주변에 있는 나와 같은 관심사를 가진 동료를 찾기 위해서는
+                                                    로컬 네트워크 권한을 필요로 합니다.
+                                                    설정 -> 개인정보 보호 및 보안 -> 로컬네트워크 에서
+                                                    권한을 허용해주세요
+                                                    """,
+                                                          preferredStyle: .alert)
+            accessAlertController.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: nil))
+            accessAlertController.addAction(UIAlertAction(title: "Go to Settings", style: .default, handler: { _ in
+                if let settingsURL = URL(string: UIApplication.openSettingsURLString) {
+                    UIApplication.shared.open(settingsURL, options: [:], completionHandler: nil)
+                }
+            }))
+            window.rootViewController?.present(accessAlertController, animated: true)
+            return
+        }
+        self.startNearbyInteractionSession()
     }
 }

--- a/2022/Playgrounds/CheeringCard/PeerConnection/NearbyInteractionManager.swift
+++ b/2022/Playgrounds/CheeringCard/PeerConnection/NearbyInteractionManager.swift
@@ -1,0 +1,60 @@
+//
+//  NearbyInteractionManager.swift
+//  LetSwift
+//
+//  Created by Noah on 2022/11/24.
+//
+
+import Combine
+import Foundation
+import NearbyInteraction
+import UIKit
+
+final class NearbyInteractionManager: NSObject {
+    // MARK: - properties
+    
+    private var session: NISession?
+    private var peerDiscoveryToken: NIDiscoveryToken?
+    private(set) var localDiscoveryToken: NIDiscoveryToken?
+    @Published var updatedNearbyObject: NINearbyObject?
+    let sessionEstablished: PassthroughSubject<Void, Never>
+    
+    override init() {
+        self.sessionEstablished = PassthroughSubject()
+        super.init()
+        self.startNearbyInteractionSession()
+    }
+    
+    // MARK: - func
+    
+    /// NISession을 initiate합니다.
+    func initiateNearbySession() {
+        guard let peerDiscoveryToken
+        else { return }
+        
+        let configuration = NINearbyPeerConfiguration(peerToken: peerDiscoveryToken)
+        self.session?.run(configuration)
+        self.sessionEstablished.send()
+    }
+    
+    /// NISession을 무효화합니다.
+    func sessionInvalidate() {
+        self.session?.invalidate()
+    }
+    
+    /// NearbyInteractionSession을 시작합니다.
+    func startNearbyInteractionSession() {
+        /// 이전 세션이 있다면 세션을 종료합니다.
+        self.sessionInvalidate()
+        self.session = NISession()
+        self.localDiscoveryToken = self.session?.discoveryToken
+        self.setNearbyInteractionSessionDelegate()
+    }
+}
+
+private extension NearbyInteractionManager {
+    // MARK: - private func
+    func setNearbyInteractionSessionDelegate() {
+        self.session?.delegate = self
+    }
+}

--- a/2022/Playgrounds/CheeringCard/PeerConnection/PeerConnectionController.swift
+++ b/2022/Playgrounds/CheeringCard/PeerConnection/PeerConnectionController.swift
@@ -54,6 +54,11 @@ final class PeerConnectionController {
         self.stopNearbyInteractionManager()
     }
     
+    /// peer를 MultipeerConnectivity session에 초대합니다.
+    func invite(to peerID: MCPeerID) {
+        self.multipeerConnectivityManager.invite(to: peerID)
+    }
+    
     /// peer와의 연결을 해제합니다.
     func disconnectToPeerDevice() {
         self.disconnectMCSession()

--- a/2022/Playgrounds/CheeringCard/PeerConnection/PeerConnectionController.swift
+++ b/2022/Playgrounds/CheeringCard/PeerConnection/PeerConnectionController.swift
@@ -1,0 +1,38 @@
+//
+//  PeerConnectionController.swift
+//  LetSwift
+//
+//  Created by Noah on 2022/11/24.
+//
+
+import Combine
+import Foundation
+import MultipeerConnectivity
+import NearbyInteraction
+
+/// NearbyInteractionManager와 MultipeerConnectivity의 상호작용을 관리하는 클래스입니다.
+final class PeerConnectionController {
+    // MARK: - properties
+    
+    /// 현재 주변에 발견된 peer들을 저장하고 있는 배열입니다.
+    @Published var peers: [Peer]
+    /// NearbyInteraction Session의 연결 상태를 나타냅니다.
+    @Published var isNISessionEstablished: Bool
+    @Published var distanceToPeerDevice: Float?
+    @Published var connectedPeer: Peer?
+    private let nearbyInteractionManager: NearbyInteractionManager
+    private let multipeerConnectivityManager: MultipeerConnectivityManager
+    private var cancellables: Set<AnyCancellable>
+    private var isTokenSharedWithPeer: Bool
+    
+    // MARK: - init
+    
+    init() {
+        self.peers = []
+        self.isNISessionEstablished = false
+        self.isTokenSharedWithPeer = false
+        self.nearbyInteractionManager = NearbyInteractionManager()
+        self.multipeerConnectivityManager = MultipeerConnectivityManager()
+        self.cancellables = Set<AnyCancellable>()
+    }
+}

--- a/2022/Playgrounds/CheeringCard/PeerConnection/PeerConnectionController.swift
+++ b/2022/Playgrounds/CheeringCard/PeerConnection/PeerConnectionController.swift
@@ -38,6 +38,8 @@ final class PeerConnectionController {
         self.bindToNearbyInteractionManager()
     }
     
+    // MARK: - func
+    
     /// peer와의 연결을 해제합니다.
     func disconnectToPeerDevice() {
         self.disconnectMCSession()
@@ -111,6 +113,11 @@ private extension PeerConnectionController {
         self.peers.remove(at: index)
     }
     
+    /// 연결된 peer와의 거리를 업데이트 합니다.
+    func updateDistanceToPeerDevice(with nearbyObject: NINearbyObject) {
+        self.distanceToPeerDevice = nearbyObject.distance
+    }
+    
     /// PeerConnectionManager의 이벤트를 전달받기 위해 PeerConnectionManager의 프로퍼티와 바인딩합니다.
     func bindToPeerConnectionManager() {
         self.multipeerConnectivityManager.$receivedPeerID
@@ -151,13 +158,13 @@ private extension PeerConnectionController {
             .receive(on: DispatchQueue.main)
             .compactMap({ $0 })
             .sink { [weak self] nearbyObject in
-                
+                self?.updateDistanceToPeerDevice(with: nearbyObject)
             }.store(in: &self.cancellables)
         
         self.nearbyInteractionManager.sessionEstablished
             .receive(on: DispatchQueue.main)
             .sink { [weak self] in
-                
+                self?.isNISessionEstablished = true
             }.store(in: &self.cancellables)
     }
 }

--- a/2022/Playgrounds/CheeringCard/PeerConnection/PeerConnectionController.swift
+++ b/2022/Playgrounds/CheeringCard/PeerConnection/PeerConnectionController.swift
@@ -64,6 +64,11 @@ final class PeerConnectionController {
         self.disconnectMCSession()
         self.disconnectNISession()
     }
+    
+    deinit {
+        self.stopPeerConenctionController()
+        self.peers.removeAll()
+    }
 }
 
 private extension PeerConnectionController {

--- a/2022/Playgrounds/CheeringCard/PeerConnection/PeerConnectionController.swift
+++ b/2022/Playgrounds/CheeringCard/PeerConnection/PeerConnectionController.swift
@@ -37,6 +37,12 @@ final class PeerConnectionController {
         self.bindToPeerConnectionManager()
         self.bindToNearbyInteractionManager()
     }
+    
+    /// peer와의 연결을 해제합니다.
+    func disconnectToPeerDevice() {
+        self.disconnectMCSession()
+        self.disconnectNISession()
+    }
 }
 
 private extension PeerConnectionController {
@@ -44,6 +50,19 @@ private extension PeerConnectionController {
     
     func connected(peerID: MCPeerID) {
         self.connectedPeer = Peer(id: peerID)
+    }
+    
+    /// MCSession을 종료시키기 위해 사용합니다.
+    func disconnectMCSession() {
+        self.connectedPeer = nil
+        self.multipeerConnectivityManager.disconnectSession()
+    }
+    
+    /// NISession을 종료시키기 위해 사용합니다.
+    func disconnectNISession() {
+        self.nearbyInteractionManager.sessionInvalidate()
+        self.isNISessionEstablished = false
+        self.isTokenSharedWithPeer = false
     }
     
     /// PeerConnectionManager의 이벤트를 전달받기 위해 PeerConnectionManager의 프로퍼티와 바인딩합니다.
@@ -69,7 +88,7 @@ private extension PeerConnectionController {
         self.multipeerConnectivityManager.peerNotConnected
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
-                
+                self?.disconnectToPeerDevice()
             }.store(in: &self.cancellables)
         
         self.multipeerConnectivityManager.dataReceived

--- a/2022/Playgrounds/CheeringCard/PeerConnection/PeerConnectionController.swift
+++ b/2022/Playgrounds/CheeringCard/PeerConnection/PeerConnectionController.swift
@@ -34,5 +34,59 @@ final class PeerConnectionController {
         self.nearbyInteractionManager = NearbyInteractionManager()
         self.multipeerConnectivityManager = MultipeerConnectivityManager()
         self.cancellables = Set<AnyCancellable>()
+        self.bindToPeerConnectionManager()
+        self.bindToNearbyInteractionManager()
+    }
+}
+
+private extension PeerConnectionController {
+    // MARK: - private func
+    
+    /// PeerConnectionManager의 이벤트를 전달받기 위해 PeerConnectionManager의 프로퍼티와 바인딩합니다.
+    func bindToPeerConnectionManager() {
+        self.multipeerConnectivityManager.$receivedPeerID
+            .receive(on: DispatchQueue.main)
+            .compactMap({ $0 })
+            .sink { [weak self] peerID in
+                
+            }.store(in: &self.cancellables)
+        
+        self.multipeerConnectivityManager.peerLosted
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] peerID in
+                
+            }.store(in: &self.cancellables)
+        
+        self.multipeerConnectivityManager.peerConnected
+            .sink { [weak self] peerID in
+                
+            }.store(in: &self.cancellables)
+        
+        self.multipeerConnectivityManager.peerNotConnected
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                
+            }.store(in: &self.cancellables)
+        
+        self.multipeerConnectivityManager.dataReceived
+            .sink { [weak self] (peerID, data) in
+                
+            }.store(in: &self.cancellables)
+    }
+    
+    /// NearbyInteraction의 이벤트를 전달받기 위해 PeerConnectionManager의 프로퍼티와 바인딩합니다.
+    func bindToNearbyInteractionManager() {
+        self.nearbyInteractionManager.$updatedNearbyObject
+            .receive(on: DispatchQueue.main)
+            .compactMap({ $0 })
+            .sink { [weak self] nearbyObject in
+                
+            }.store(in: &self.cancellables)
+        
+        self.nearbyInteractionManager.sessionEstablished
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] in
+                
+            }.store(in: &self.cancellables)
     }
 }

--- a/2022/Playgrounds/CheeringCard/PeerConnection/PeerConnectionController.swift
+++ b/2022/Playgrounds/CheeringCard/PeerConnection/PeerConnectionController.swift
@@ -102,6 +102,15 @@ private extension PeerConnectionController {
         }
     }
     
+    /// 사라진 peer를 peers배열에서 삭제합니다.
+    func losted(peerID: MCPeerID) {
+        guard let index = self.peers.firstIndex(where: { peer in
+            peer.id == peerID
+        })
+        else { return }
+        self.peers.remove(at: index)
+    }
+    
     /// PeerConnectionManager의 이벤트를 전달받기 위해 PeerConnectionManager의 프로퍼티와 바인딩합니다.
     func bindToPeerConnectionManager() {
         self.multipeerConnectivityManager.$receivedPeerID
@@ -114,7 +123,7 @@ private extension PeerConnectionController {
         self.multipeerConnectivityManager.peerLosted
             .receive(on: DispatchQueue.main)
             .sink { [weak self] peerID in
-                
+                self?.losted(peerID: peerID)
             }.store(in: &self.cancellables)
         
         self.multipeerConnectivityManager.peerConnected

--- a/2022/Playgrounds/CheeringCard/PeerConnection/PeerConnectionController.swift
+++ b/2022/Playgrounds/CheeringCard/PeerConnection/PeerConnectionController.swift
@@ -40,6 +40,20 @@ final class PeerConnectionController {
     
     // MARK: - func
     
+    /// PeeerConnectionController를 시작합니다.
+    /// > 이전에 연결된 session이 있다면 연결을 해제한 후에 사용하기위해 ``self.multipeerConnectivityManager.disconnectSession()``을 호출합니다.
+    func startPeerConnetionController() {
+        self.multipeerConnectivityManager.disconnectSession()
+        self.startMultiPeerConnectionManager()
+        self.startNearbyInteractionManager()
+    }
+    
+    /// PeerConnectionController를 종료합니다.
+    func stopPeerConenctionController() {
+        self.stopMultiPeerConnectionManager()
+        self.stopNearbyInteractionManager()
+    }
+    
     /// peer와의 연결을 해제합니다.
     func disconnectToPeerDevice() {
         self.disconnectMCSession()
@@ -65,6 +79,24 @@ private extension PeerConnectionController {
         self.nearbyInteractionManager.sessionInvalidate()
         self.isNISessionEstablished = false
         self.isTokenSharedWithPeer = false
+    }
+    
+    func startNearbyInteractionManager() {
+        self.nearbyInteractionManager.startNearbyInteractionSession()
+    }
+    
+    func startMultiPeerConnectionManager() {
+        self.multipeerConnectivityManager.startMultiPeerConnectionManager()
+    }
+    
+    func stopMultiPeerConnectionManager() {
+        self.connectedPeer = nil
+        self.multipeerConnectivityManager.stopMultiPeerConnectionManager()
+    }
+    
+    func stopNearbyInteractionManager() {
+        self.isNISessionEstablished = false
+        self.nearbyInteractionManager.sessionInvalidate()
     }
     
     /// NearybyInteraction 프레임워크를 사용하기 위해 연결된 peer에게 MultiPeerConenctivityManager를 이용해 DiscoveryToken을 전송합니다.
@@ -97,6 +129,7 @@ private extension PeerConnectionController {
     
     /// 발견된 peer를 peers 배열에 추가합니다.
     func received(peerID: MCPeerID) {
+        print("print peer founded: \(peerID.displayName)")
         if self.peers.contains(where: { peer in
             peer.id == peerID
         }) == false {

--- a/2022/Playgrounds/CheeringCard/PeerConnection/PeerConnectionController.swift
+++ b/2022/Playgrounds/CheeringCard/PeerConnection/PeerConnectionController.swift
@@ -93,13 +93,22 @@ private extension PeerConnectionController {
         self.nearbyInteractionManager.initiateNearbySession()
     }
     
+    /// 발견된 peer를 peers 배열에 추가합니다.
+    func received(peerID: MCPeerID) {
+        if self.peers.contains(where: { peer in
+            peer.id == peerID
+        }) == false {
+            self.peers.append(Peer(id: peerID))
+        }
+    }
+    
     /// PeerConnectionManager의 이벤트를 전달받기 위해 PeerConnectionManager의 프로퍼티와 바인딩합니다.
     func bindToPeerConnectionManager() {
         self.multipeerConnectivityManager.$receivedPeerID
             .receive(on: DispatchQueue.main)
             .compactMap({ $0 })
             .sink { [weak self] peerID in
-                
+                self?.received(peerID: peerID)
             }.store(in: &self.cancellables)
         
         self.multipeerConnectivityManager.peerLosted

--- a/2022/Playgrounds/CheeringCard/PeerConnection/PeerConnectionController.swift
+++ b/2022/Playgrounds/CheeringCard/PeerConnection/PeerConnectionController.swift
@@ -42,6 +42,10 @@ final class PeerConnectionController {
 private extension PeerConnectionController {
     // MARK: - private func
     
+    func connected(peerID: MCPeerID) {
+        self.connectedPeer = Peer(id: peerID)
+    }
+    
     /// PeerConnectionManager의 이벤트를 전달받기 위해 PeerConnectionManager의 프로퍼티와 바인딩합니다.
     func bindToPeerConnectionManager() {
         self.multipeerConnectivityManager.$receivedPeerID
@@ -59,7 +63,7 @@ private extension PeerConnectionController {
         
         self.multipeerConnectivityManager.peerConnected
             .sink { [weak self] peerID in
-                
+                self?.connected(peerID: peerID)
             }.store(in: &self.cancellables)
         
         self.multipeerConnectivityManager.peerNotConnected

--- a/2022/Utility/String+Extension.swift
+++ b/2022/Utility/String+Extension.swift
@@ -21,4 +21,10 @@ extension String {
         return attributedStr
         
     }
+    
+    func utf8EncodedString()-> String {
+        let messageData = self.data(using: .nonLossyASCII)
+        let text = String(data: messageData!, encoding: .utf8) ?? ""
+        return text
+    }
 }

--- a/2022/Utility/String+Extension.swift
+++ b/2022/Utility/String+Extension.swift
@@ -22,9 +22,11 @@ extension String {
         
     }
     
-    func utf8EncodedString()-> String {
-        let messageData = self.data(using: .nonLossyASCII)
-        let text = String(data: messageData!, encoding: .utf8) ?? ""
+    func utf8EncodedString() -> String {
+        guard let messageData = self.data(using: .nonLossyASCII),
+              let text = String(data: messageData, encoding: .utf8)
+        else { return "" }
+        
         return text
     }
 }

--- a/App/iOS/Info.plist
+++ b/App/iOS/Info.plist
@@ -54,6 +54,11 @@
 		<key>NSAllowsArbitraryLoads</key>
 		<true/>
 	</dict>
+	<key>NSBonjourServices</key>
+	<array>
+		<string>_letswift._tcp</string>
+		<string>_letswift._udp</string>
+	</array>
 	<key>NSCalendarsUsageDescription</key>
 	<string>Allow access to save event to calendar.</string>
 	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
@@ -61,9 +66,9 @@
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>행사장까지 남은 거리를 계산하기 위해 권한이 필요합니다. (필수권한)</string>
 	<key>NSLocalNetworkUsageDescription</key>
-	<string>나와 관심사가 비슷한 동료를 찾기 위해 로컬 네트워크 권한을 허용해주세요.</string>
+	<string>나와 관심사가 비슷한 동료를 찾기 위해 로컬 네트워크 권한을 필요로 합니다.</string>
 	<key>NSNearbyInteractionUsageDescription</key>
-	<string>나와 관심사가 비슷한 동료를 찾기 위해 근처 상호작용 권한을 허용해주세요.</string>
+	<string>나와 관심사가 비슷한 동료를 찾기 위해 근처 상호작용 권한을 필요로 합니다.</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>Playground Card를 갤러리에 저장하기 위해 앨범 쓰기 권한을 허용해주세요.</string>
 	<key>UIApplicationSceneManifest</key>

--- a/App/iOS/Info.plist
+++ b/App/iOS/Info.plist
@@ -60,6 +60,10 @@
 	<string>행사장까지 남은 거리를 계산하기 위해 권한이 필요합니다. (필수권한)</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>행사장까지 남은 거리를 계산하기 위해 권한이 필요합니다. (필수권한)</string>
+	<key>NSLocalNetworkUsageDescription</key>
+	<string>나와 관심사가 비슷한 동료를 찾기 위해 로컬 네트워크 권한을 허용해주세요.</string>
+	<key>NSNearbyInteractionUsageDescription</key>
+	<string>나와 관심사가 비슷한 동료를 찾기 위해 근처 상호작용 권한을 허용해주세요.</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>Playground Card를 갤러리에 저장하기 위해 앨범 쓰기 권한을 허용해주세요.</string>
 	<key>UIApplicationSceneManifest</key>

--- a/LetSwift.xcodeproj/project.pbxproj
+++ b/LetSwift.xcodeproj/project.pbxproj
@@ -124,6 +124,7 @@
 		4FFB9A93292F592000182AA4 /* Peer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FFB9A92292F592000182AA4 /* Peer.swift */; };
 		4FFB9A95292F907200182AA4 /* MultipeerConnectivityManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FFB9A94292F907200182AA4 /* MultipeerConnectivityManager.swift */; };
 		4FFB9A97292F9FA800182AA4 /* NearbyInteractionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FFB9A96292F9FA800182AA4 /* NearbyInteractionManager.swift */; };
+		4FFB9A99292FA31500182AA4 /* PeerConnectionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FFB9A98292FA31500182AA4 /* PeerConnectionController.swift */; };
 		551BC154292A248C00DBD819 /* CardType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 551BC153292A248C00DBD819 /* CardType.swift */; };
 		555CB611291CC38B00D893CE /* GoToCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 555CB60F291CC38B00D893CE /* GoToCardView.swift */; };
 		555CB61A291CC3B800D893CE /* CardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 555CB614291CC3B700D893CE /* CardView.swift */; };
@@ -404,6 +405,7 @@
 		4FFB9A92292F592000182AA4 /* Peer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Peer.swift; sourceTree = "<group>"; };
 		4FFB9A94292F907200182AA4 /* MultipeerConnectivityManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultipeerConnectivityManager.swift; sourceTree = "<group>"; };
 		4FFB9A96292F9FA800182AA4 /* NearbyInteractionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NearbyInteractionManager.swift; sourceTree = "<group>"; };
+		4FFB9A98292FA31500182AA4 /* PeerConnectionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeerConnectionController.swift; sourceTree = "<group>"; };
 		515AC2D1A6538F4AFA509A31 /* Pods-ScheduleWidgetExtension.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ScheduleWidgetExtension.release.xcconfig"; path = "Target Support Files/Pods-ScheduleWidgetExtension/Pods-ScheduleWidgetExtension.release.xcconfig"; sourceTree = "<group>"; };
 		551BC153292A248C00DBD819 /* CardType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardType.swift; sourceTree = "<group>"; };
 		555CB60F291CC38B00D893CE /* GoToCardView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GoToCardView.swift; sourceTree = "<group>"; };
@@ -892,6 +894,7 @@
 				4FFB9A91292F591800182AA4 /* Model */,
 				4FFB9A94292F907200182AA4 /* MultipeerConnectivityManager.swift */,
 				4FFB9A96292F9FA800182AA4 /* NearbyInteractionManager.swift */,
+				4FFB9A98292FA31500182AA4 /* PeerConnectionController.swift */,
 			);
 			path = PeerConnection;
 			sourceTree = "<group>";
@@ -1826,6 +1829,7 @@
 				6FC0FD312927C56A0026714A /* QuestionData.swift in Sources */,
 				6F3A3E5329196E1E00E42D64 /* View.swift in Sources */,
 				4FFB9A97292F9FA800182AA4 /* NearbyInteractionManager.swift in Sources */,
+				4FFB9A99292FA31500182AA4 /* PeerConnectionController.swift in Sources */,
 				16DBE6342569EAD200B334A3 /* LetSwiftApp.swift in Sources */,
 				6FC0FD2E2927C55C0026714A /* BackgroundView.swift in Sources */,
 				6F3A3E6C291EA07100E42D64 /* LetSwiftAPI.swift in Sources */,

--- a/LetSwift.xcodeproj/project.pbxproj
+++ b/LetSwift.xcodeproj/project.pbxproj
@@ -121,6 +121,7 @@
 		16DBE6CB256A2EC800B334A3 /* Application.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16DBE6C8256A2EC800B334A3 /* Application.swift */; };
 		16DBE6CC256A2EC800B334A3 /* Color.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16DBE6C9256A2EC800B334A3 /* Color.swift */; };
 		3C07063899855A671DDB6508 /* Pods_LetSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8ACD22972F91777DDDC6609F /* Pods_LetSwift.framework */; };
+		4FFB9A93292F592000182AA4 /* Peer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FFB9A92292F592000182AA4 /* Peer.swift */; };
 		551BC154292A248C00DBD819 /* CardType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 551BC153292A248C00DBD819 /* CardType.swift */; };
 		555CB611291CC38B00D893CE /* GoToCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 555CB60F291CC38B00D893CE /* GoToCardView.swift */; };
 		555CB61A291CC3B800D893CE /* CardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 555CB614291CC3B700D893CE /* CardView.swift */; };
@@ -398,6 +399,7 @@
 		1F3309A495A5037695D25036 /* Pods_Upcoming1WidgetExtension.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Upcoming1WidgetExtension.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		2CEE5D31BF7A0CE9C14548DD /* Pods-Upcoming2WidgetExtension.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Upcoming2WidgetExtension.debug.xcconfig"; path = "Target Support Files/Pods-Upcoming2WidgetExtension/Pods-Upcoming2WidgetExtension.debug.xcconfig"; sourceTree = "<group>"; };
 		34AF4FE1450E9DA065A22F07 /* Pods-Upcoming2WidgetExtension.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Upcoming2WidgetExtension.release.xcconfig"; path = "Target Support Files/Pods-Upcoming2WidgetExtension/Pods-Upcoming2WidgetExtension.release.xcconfig"; sourceTree = "<group>"; };
+		4FFB9A92292F592000182AA4 /* Peer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Peer.swift; sourceTree = "<group>"; };
 		515AC2D1A6538F4AFA509A31 /* Pods-ScheduleWidgetExtension.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ScheduleWidgetExtension.release.xcconfig"; path = "Target Support Files/Pods-ScheduleWidgetExtension/Pods-ScheduleWidgetExtension.release.xcconfig"; sourceTree = "<group>"; };
 		551BC153292A248C00DBD819 /* CardType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardType.swift; sourceTree = "<group>"; };
 		555CB60F291CC38B00D893CE /* GoToCardView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GoToCardView.swift; sourceTree = "<group>"; };
@@ -880,6 +882,22 @@
 			path = Pods;
 			sourceTree = "<group>";
 		};
+		4FFB9A81292CDA1B00182AA4 /* PeerConnection */ = {
+			isa = PBXGroup;
+			children = (
+				4FFB9A91292F591800182AA4 /* Model */,
+			);
+			path = PeerConnection;
+			sourceTree = "<group>";
+		};
+		4FFB9A91292F591800182AA4 /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				4FFB9A92292F592000182AA4 /* Peer.swift */,
+			);
+			path = Model;
+			sourceTree = "<group>";
+		};
 		5529B6212920292600803956 /* Data */ = {
 			isa = PBXGroup;
 			children = (
@@ -894,6 +912,7 @@
 		555CB60D291CC37900D893CE /* CheeringCard */ = {
 			isa = PBXGroup;
 			children = (
+				4FFB9A81292CDA1B00182AA4 /* PeerConnection */,
 				555CB617291CC3B700D893CE /* NicknameView.swift */,
 				555CB616291CC3B700D893CE /* SurveyView.swift */,
 				555CB615291CC3B700D893CE /* AnswerItemView.swift */,
@@ -1743,6 +1762,7 @@
 				16DBE6B1256A283E00B334A3 /* PeopleView.swift in Sources */,
 				6F3A3E72291F3CD800E42D64 /* NetworkLoggingPlugin.swift in Sources */,
 				A5704B1B256E8E2500EB6C8F /* DateFormatter.swift in Sources */,
+				4FFB9A93292F592000182AA4 /* Peer.swift in Sources */,
 				551BC154292A248C00DBD819 /* CardType.swift in Sources */,
 				CCF9A0C2291CE1C100EF8C9B /* SettingMainView.swift in Sources */,
 				6FC0FD212927C5030026714A /* BadgeView.swift in Sources */,

--- a/LetSwift.xcodeproj/project.pbxproj
+++ b/LetSwift.xcodeproj/project.pbxproj
@@ -123,6 +123,7 @@
 		3C07063899855A671DDB6508 /* Pods_LetSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8ACD22972F91777DDDC6609F /* Pods_LetSwift.framework */; };
 		4FFB9A93292F592000182AA4 /* Peer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FFB9A92292F592000182AA4 /* Peer.swift */; };
 		4FFB9A95292F907200182AA4 /* MultipeerConnectivityManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FFB9A94292F907200182AA4 /* MultipeerConnectivityManager.swift */; };
+		4FFB9A97292F9FA800182AA4 /* NearbyInteractionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FFB9A96292F9FA800182AA4 /* NearbyInteractionManager.swift */; };
 		551BC154292A248C00DBD819 /* CardType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 551BC153292A248C00DBD819 /* CardType.swift */; };
 		555CB611291CC38B00D893CE /* GoToCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 555CB60F291CC38B00D893CE /* GoToCardView.swift */; };
 		555CB61A291CC3B800D893CE /* CardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 555CB614291CC3B700D893CE /* CardView.swift */; };
@@ -402,6 +403,7 @@
 		34AF4FE1450E9DA065A22F07 /* Pods-Upcoming2WidgetExtension.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Upcoming2WidgetExtension.release.xcconfig"; path = "Target Support Files/Pods-Upcoming2WidgetExtension/Pods-Upcoming2WidgetExtension.release.xcconfig"; sourceTree = "<group>"; };
 		4FFB9A92292F592000182AA4 /* Peer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Peer.swift; sourceTree = "<group>"; };
 		4FFB9A94292F907200182AA4 /* MultipeerConnectivityManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultipeerConnectivityManager.swift; sourceTree = "<group>"; };
+		4FFB9A96292F9FA800182AA4 /* NearbyInteractionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NearbyInteractionManager.swift; sourceTree = "<group>"; };
 		515AC2D1A6538F4AFA509A31 /* Pods-ScheduleWidgetExtension.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ScheduleWidgetExtension.release.xcconfig"; path = "Target Support Files/Pods-ScheduleWidgetExtension/Pods-ScheduleWidgetExtension.release.xcconfig"; sourceTree = "<group>"; };
 		551BC153292A248C00DBD819 /* CardType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardType.swift; sourceTree = "<group>"; };
 		555CB60F291CC38B00D893CE /* GoToCardView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GoToCardView.swift; sourceTree = "<group>"; };
@@ -889,6 +891,7 @@
 			children = (
 				4FFB9A91292F591800182AA4 /* Model */,
 				4FFB9A94292F907200182AA4 /* MultipeerConnectivityManager.swift */,
+				4FFB9A96292F9FA800182AA4 /* NearbyInteractionManager.swift */,
 			);
 			path = PeerConnection;
 			sourceTree = "<group>";
@@ -1822,6 +1825,7 @@
 				55AA19B029252096003F1AA5 /* CheeringCardModel.swift in Sources */,
 				6FC0FD312927C56A0026714A /* QuestionData.swift in Sources */,
 				6F3A3E5329196E1E00E42D64 /* View.swift in Sources */,
+				4FFB9A97292F9FA800182AA4 /* NearbyInteractionManager.swift in Sources */,
 				16DBE6342569EAD200B334A3 /* LetSwiftApp.swift in Sources */,
 				6FC0FD2E2927C55C0026714A /* BackgroundView.swift in Sources */,
 				6F3A3E6C291EA07100E42D64 /* LetSwiftAPI.swift in Sources */,

--- a/LetSwift.xcodeproj/project.pbxproj
+++ b/LetSwift.xcodeproj/project.pbxproj
@@ -122,6 +122,7 @@
 		16DBE6CC256A2EC800B334A3 /* Color.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16DBE6C9256A2EC800B334A3 /* Color.swift */; };
 		3C07063899855A671DDB6508 /* Pods_LetSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8ACD22972F91777DDDC6609F /* Pods_LetSwift.framework */; };
 		4FFB9A93292F592000182AA4 /* Peer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FFB9A92292F592000182AA4 /* Peer.swift */; };
+		4FFB9A95292F907200182AA4 /* MultipeerConnectivityManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FFB9A94292F907200182AA4 /* MultipeerConnectivityManager.swift */; };
 		551BC154292A248C00DBD819 /* CardType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 551BC153292A248C00DBD819 /* CardType.swift */; };
 		555CB611291CC38B00D893CE /* GoToCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 555CB60F291CC38B00D893CE /* GoToCardView.swift */; };
 		555CB61A291CC3B800D893CE /* CardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 555CB614291CC3B700D893CE /* CardView.swift */; };
@@ -400,6 +401,7 @@
 		2CEE5D31BF7A0CE9C14548DD /* Pods-Upcoming2WidgetExtension.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Upcoming2WidgetExtension.debug.xcconfig"; path = "Target Support Files/Pods-Upcoming2WidgetExtension/Pods-Upcoming2WidgetExtension.debug.xcconfig"; sourceTree = "<group>"; };
 		34AF4FE1450E9DA065A22F07 /* Pods-Upcoming2WidgetExtension.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Upcoming2WidgetExtension.release.xcconfig"; path = "Target Support Files/Pods-Upcoming2WidgetExtension/Pods-Upcoming2WidgetExtension.release.xcconfig"; sourceTree = "<group>"; };
 		4FFB9A92292F592000182AA4 /* Peer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Peer.swift; sourceTree = "<group>"; };
+		4FFB9A94292F907200182AA4 /* MultipeerConnectivityManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultipeerConnectivityManager.swift; sourceTree = "<group>"; };
 		515AC2D1A6538F4AFA509A31 /* Pods-ScheduleWidgetExtension.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ScheduleWidgetExtension.release.xcconfig"; path = "Target Support Files/Pods-ScheduleWidgetExtension/Pods-ScheduleWidgetExtension.release.xcconfig"; sourceTree = "<group>"; };
 		551BC153292A248C00DBD819 /* CardType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardType.swift; sourceTree = "<group>"; };
 		555CB60F291CC38B00D893CE /* GoToCardView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GoToCardView.swift; sourceTree = "<group>"; };
@@ -886,6 +888,7 @@
 			isa = PBXGroup;
 			children = (
 				4FFB9A91292F591800182AA4 /* Model */,
+				4FFB9A94292F907200182AA4 /* MultipeerConnectivityManager.swift */,
 			);
 			path = PeerConnection;
 			sourceTree = "<group>";
@@ -1800,6 +1803,7 @@
 				555CB61C291CC3B800D893CE /* SurveyView.swift in Sources */,
 				C6CDB2E1292C2D6C00960FBF /* SurveyData.swift in Sources */,
 				6FE5D03A291F9F2C001F6880 /* Toast.swift in Sources */,
+				4FFB9A95292F907200182AA4 /* MultipeerConnectivityManager.swift in Sources */,
 				C6CDB2DB292B84B600960FBF /* SessionDetailView+PresentationInformationView.swift in Sources */,
 				A5704B18256E510C00EB6C8F /* UNUserNotificationCenter.swift in Sources */,
 				C6CDB2DD292B84D300960FBF /* SessionDetailView+SpeakerInformationView.swift in Sources */,


### PR DESCRIPTION
### 구현한 내용
- [x] 사용자와 응원카드 타입이 같은 주변 사용자들을 찾고, NearbyInteraction framework을 이용해 연결된 사용자와의 거리를 측정합니다.
- [x] MultiPeerConnectivityManager 구현
- [x] NearbyInteractionManager 구현
- [x] PeerConnectionController 구현

- 사용자와 응원카드 타입이 같은 주변 사용자들을 찾기 위해 MCNearbyServiceAdvertiser의 discoveryInfo 옵션을 사용하였습니다.
- MCNearbyServiceAdvertiser의 info에서는 utf8, us-ascii를 사용해야합니다.
- 현재 응원카드 정보가 한글로 저장되어있어 해당정보를 utf8로 변환하여 사용하였습니다.
- link: 
https://developer.apple.com/documentation/multipeerconnectivity/mcadvertiserassistant/1406990-initwithservicetype/?language%5C=objc

### TODO
- peer 목록과 연결된 peer와의 거리를 나타내는 뷰를 구현해야합니다.

### 화면
- 아래화면은 test용 화면입니다.

| test 화면	|
|----------------	|
| ![Screen Recording 2022-11-24 at 23 12 20-min](https://user-images.githubusercontent.com/63908856/203807154-72496c8e-a7af-410e-876e-80109c6de8fb.gif)|

