### PR TITLE
[feat] 동료찾기 화면 구현

### DIFF
--- a/2022/Playgrounds/CheeringCard/CardView.swift
+++ b/2022/Playgrounds/CheeringCard/CardView.swift
@@ -102,8 +102,12 @@ struct CardView: View {
                             boxText(title: "카드 공유", image: "square.and.arrow.up")
                         }
                         Spacer()
-                        Button {
-                            // action
+                        NavigationLink {
+                            PeerListView(
+                                viewModel: PeerListViewModel(
+                                    peerConnectionController: PeerConnectionController()
+                                )
+                            )
                         } label: {
                             boxText(title: "동료 찾기", image: "magnifyingglass")
                         }

--- a/2022/Playgrounds/CheeringCard/PeerConnection/MultipeerConnectivityManager.swift
+++ b/2022/Playgrounds/CheeringCard/PeerConnection/MultipeerConnectivityManager.swift
@@ -15,7 +15,7 @@ final class MultipeerConnectivityManager: NSObject {
     /// 응원카드의 타입이 같은 사용자와의 연결을 위한 필드입니다.
     private let cheeringCardType: String
     private let session: MCSession
-    private let localPeerId: MCPeerID
+    private let localPeerID: MCPeerID
     @Published var receivedPeerID: MCPeerID?
     private let nearbyServiceBrowser: MCNearbyServiceBrowser
     private let nearbyServiceAdvertiser: MCNearbyServiceAdvertiser
@@ -28,21 +28,21 @@ final class MultipeerConnectivityManager: NSObject {
         let serviceType = "letswift"
         self.cheeringCardType = MultipeerConnectivityManager.getCheeringCardType()
         
-        self.localPeerId = MCPeerID(
+        self.localPeerID = MCPeerID(
             displayName: MultipeerConnectivityManager.getUserName()
         )
         self.session = MCSession(
-            peer: self.localPeerId,
+            peer: self.localPeerID,
             securityIdentity: nil,
             encryptionPreference: .none
         )
         self.nearbyServiceAdvertiser = MCNearbyServiceAdvertiser(
-            peer: self.localPeerId,
+            peer: self.localPeerID,
             discoveryInfo: [self.cheeringCardType: self.cheeringCardType],
             serviceType: serviceType
         )
         self.nearbyServiceBrowser = MCNearbyServiceBrowser(
-            peer: self.localPeerId,
+            peer: self.localPeerID,
             serviceType: serviceType
         )
         self.peerConnected = PassthroughSubject()

--- a/2022/Playgrounds/CheeringCard/PeerConnection/MultipeerConnectivityManager.swift
+++ b/2022/Playgrounds/CheeringCard/PeerConnection/MultipeerConnectivityManager.swift
@@ -132,7 +132,8 @@ extension MultipeerConnectivityManager: MCNearbyServiceAdvertiserDelegate {
         guard
             let window = windowScene?.windows.first,
             let context = context,
-            let peerName = String(data: context, encoding: .utf8)
+            let peerName = String(data: context, encoding: .utf8),
+            let rootViewController = window.rootViewController
         else { return }
     
         let title = "\(peerName)와 연결"
@@ -142,7 +143,9 @@ extension MultipeerConnectivityManager: MCNearbyServiceAdvertiserDelegate {
         alertController.addAction(UIAlertAction(title: "Yes", style: .default) { _ in
             invitationHandler(true, self.session)
         })
-        window.rootViewController?.present(alertController, animated: true)
+        if let presentedViewController = rootViewController.presentedViewController {
+            presentedViewController.present(alertController, animated: true)
+        }
     }
 }
 

--- a/2022/Playgrounds/CheeringCard/PeerConnection/MultipeerConnectivityManager.swift
+++ b/2022/Playgrounds/CheeringCard/PeerConnection/MultipeerConnectivityManager.swift
@@ -13,12 +13,14 @@ final class MultipeerConnectivityManager: NSObject {
     // MARK: - properties
     
     /// 응원카드의 타입이 같은 사용자와의 연결을 위한 필드입니다.
-    private let cheeringCardType: String
-    private let session: MCSession
-    private let localPeerID: MCPeerID
+    private var cheeringCardType: String
+    /// Bonjour service type에 등록된 service 명입니다.
+    private let serviceType = "letswift"
+    private var session: MCSession
+    private var localPeerID: MCPeerID
     @Published var receivedPeerID: MCPeerID?
-    private let nearbyServiceBrowser: MCNearbyServiceBrowser
-    private let nearbyServiceAdvertiser: MCNearbyServiceAdvertiser
+    private var nearbyServiceBrowser: MCNearbyServiceBrowser
+    private var nearbyServiceAdvertiser: MCNearbyServiceAdvertiser
     let peerConnected: PassthroughSubject<MCPeerID, Never>
     let peerNotConnected: PassthroughSubject<MCPeerID, Never>
     let peerLosted: PassthroughSubject<MCPeerID, Never>
@@ -76,6 +78,12 @@ final class MultipeerConnectivityManager: NSObject {
     // MARK: - func
     
     func startMultiPeerConnectionManager() {
+        self.setCheeringCardType()
+        self.setLocalPeerID()
+        self.setSession()
+        self.setNearbyServiceAdvertiser()
+        self.setNearbyServiceBrowser()
+        self.setDelegation()
         self.nearbyServiceAdvertiser.startAdvertisingPeer()
         self.nearbyServiceBrowser.startBrowsingForPeers()
     }
@@ -93,6 +101,39 @@ final class MultipeerConnectivityManager: NSObject {
 
 private extension MultipeerConnectivityManager {
     // MARK: - private func
+    
+    func setCheeringCardType() {
+        self.cheeringCardType = MultipeerConnectivityManager.getCheeringCardType()
+    }
+    
+    func setNearbyServiceBrowser() {
+        self.nearbyServiceBrowser = MCNearbyServiceBrowser(
+            peer: self.localPeerID,
+            serviceType: serviceType
+        )
+    }
+    
+    func setNearbyServiceAdvertiser() {
+        self.nearbyServiceAdvertiser = MCNearbyServiceAdvertiser(
+            peer: self.localPeerID,
+            discoveryInfo: [self.cheeringCardType: self.cheeringCardType],
+            serviceType: serviceType
+        )
+    }
+    
+    func setLocalPeerID() {
+        self.localPeerID =  MCPeerID(
+            displayName: MultipeerConnectivityManager.getUserName()
+        )
+    }
+    
+    func setSession() {
+        self.session = MCSession(
+            peer: self.localPeerID,
+            securityIdentity: nil,
+            encryptionPreference: .none
+        )
+    }
     
     func setDelegation() {
         self.session.delegate = self

--- a/2022/Playgrounds/CheeringCard/PeerConnection/NearbyInteractionManager.swift
+++ b/2022/Playgrounds/CheeringCard/PeerConnection/NearbyInteractionManager.swift
@@ -54,6 +54,15 @@ final class NearbyInteractionManager: NSObject {
         self.localDiscoveryToken = self.session?.discoveryToken
         self.setNearbyInteractionSessionDelegate()
     }
+    
+    /// Nearby Interaction framework 사용여부를 판별합니다.
+    static func isSupportedNearbyInteraction() -> Bool {
+        if #available(iOS 16.0, *) {
+            return NISession.deviceCapabilities.supportsPreciseDistanceMeasurement
+        } else {
+            return NISession.isSupported
+        }
+    }
 }
 
 private extension NearbyInteractionManager {

--- a/2022/Playgrounds/CheeringCard/PeerListView.swift
+++ b/2022/Playgrounds/CheeringCard/PeerListView.swift
@@ -8,6 +8,14 @@
 import SwiftUI
 
 struct PeerListView: View {
+    @Environment(\.dismiss) private var dismiss
+    @ObservedObject var viewModel: PeerListViewModel
+    
+    init(viewModel: PeerListViewModel) {
+        self.viewModel = viewModel
+        UICollectionView.appearance().backgroundColor = .clear
+    }
+    
     var body: some View {
         Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
     }
@@ -15,6 +23,10 @@ struct PeerListView: View {
 
 struct PeerListView_Previews: PreviewProvider {
     static var previews: some View {
-        PeerListView()
+        PeerListView(
+            viewModel: PeerListViewModel(
+                peerConnectionController: PeerConnectionController()
+            )
+        )
     }
 }

--- a/2022/Playgrounds/CheeringCard/PeerListView.swift
+++ b/2022/Playgrounds/CheeringCard/PeerListView.swift
@@ -73,6 +73,24 @@ struct PeerListView: View {
         }
         .navigationTitle("동료 찾기")
         .navigationBarTitleDisplayMode(.large)
+        .alert(isPresented: self.$viewModel.isShowAlert) {
+            Alert(title: Text("알림"),
+                  message: Text("""
+Nearby Interaction을 이용한
+동료찾기 기능은 iPhone11 이상부터 사용가능합니다.
+"""
+                               ),
+                  dismissButton: .default(
+                    Text("확인"),
+                    action: {
+                        self.dismiss()
+                    }
+                  )
+            )
+        }
+        .onAppear {
+            self.viewModel.setIsSupportedNearbyInteraction()
+        }
     }
 }
 

--- a/2022/Playgrounds/CheeringCard/PeerListView.swift
+++ b/2022/Playgrounds/CheeringCard/PeerListView.swift
@@ -1,0 +1,20 @@
+//
+//  PeerListView.swift
+//  LetSwift
+//
+//  Created by Noah on 2022/11/26.
+//
+
+import SwiftUI
+
+struct PeerListView: View {
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}
+
+struct PeerListView_Previews: PreviewProvider {
+    static var previews: some View {
+        PeerListView()
+    }
+}

--- a/2022/Playgrounds/CheeringCard/PeerListView.swift
+++ b/2022/Playgrounds/CheeringCard/PeerListView.swift
@@ -70,6 +70,12 @@ struct PeerListView: View {
             }
             .background(Color.backgroundBlack)
             .listStyle(InsetGroupedListStyle())
+            .onAppear {
+                self.viewModel.startPeerConnectionController()
+            }
+            .onDisappear {
+                self.viewModel.stopPeerConnectionController()
+            }
         }
         .navigationTitle("동료 찾기")
         .navigationBarTitleDisplayMode(.large)

--- a/2022/Playgrounds/CheeringCard/PeerListView.swift
+++ b/2022/Playgrounds/CheeringCard/PeerListView.swift
@@ -17,7 +17,42 @@ struct PeerListView: View {
     }
     
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        ZStack {
+            List {
+                if self.viewModel.isNearbySessionEstablished {
+                    Section {
+                        VStack(spacing: 20) {
+                            HStack {
+                                Image(systemName: "person.circle")
+                                Text("\(self.viewModel.peerName) 님과의 거리")
+                                    .fontWeight(.bold)
+                                Spacer()
+                                Button {
+                                    self.viewModel.disconnectToPeerDevice()
+                                } label: {
+                                    Image(systemName: "xmark")
+                                        .resizable()
+                                        .frame(width: 10, height: 10)
+                                }
+                            }
+                            HStack {
+                                Text(
+                                    "\(self.viewModel.distanceToPeerDevice)"
+                                )
+                                .font(.title)
+                                .fontWeight(.bold)
+                                Text("m")
+                                Spacer()
+                            }
+                        }
+                    }
+                }
+            }
+            .background(Color.backgroundBlack)
+            .listStyle(InsetGroupedListStyle())
+        }
+        .navigationTitle("동료 찾기")
+        .navigationBarTitleDisplayMode(.large)
     }
 }
 

--- a/2022/Playgrounds/CheeringCard/PeerListView.swift
+++ b/2022/Playgrounds/CheeringCard/PeerListView.swift
@@ -47,6 +47,26 @@ struct PeerListView: View {
                         }
                     }
                 }
+                Section(
+                    header: HStack(spacing: 8) {
+                        Text("나와 같은 응원카드를 가진 동료")
+                        Spacer()
+                        ProgressView()
+                    }
+                ) {
+                    ForEach(self.viewModel.peers, id: \.id) { peer in
+                        HStack {
+                            Text(peer.displayName)
+                                .font(.headline)
+                            Spacer()
+                            Image(systemName: "arrowshape.turn.up.right.fill")
+                        }
+                        .onTapGesture {
+                            self.viewModel.invite(to: peer.id)
+                        }
+                        .listRowBackground(Color.backgroundCell)
+                    }
+                }
             }
             .background(Color.backgroundBlack)
             .listStyle(InsetGroupedListStyle())

--- a/2022/Playgrounds/CheeringCard/PeerListViewModel.swift
+++ b/2022/Playgrounds/CheeringCard/PeerListViewModel.swift
@@ -1,0 +1,8 @@
+//
+//  PeerListViewModel.swift
+//  LetSwift
+//
+//  Created by Noah on 2022/11/26.
+//
+
+import Foundation

--- a/2022/Playgrounds/CheeringCard/PeerListViewModel.swift
+++ b/2022/Playgrounds/CheeringCard/PeerListViewModel.swift
@@ -27,6 +27,29 @@ final class PeerListViewModel: ObservableObject {
         self.peerConnectionController = peerConnectionController
         self.bindToPeerConnectionController()
     }
+    
+    // MARK: - func
+    
+    func startPeerConnectionController() {
+        self.peerConnectionController.startPeerConnetionController()
+    }
+    
+    func stopPeerConnectionController() {
+        self.peerConnectionController.stopPeerConenctionController()
+    }
+    
+    func invite(to peerID: MCPeerID) {
+        self.peerConnectionController.disconnectToPeerDevice()
+        self.peerConnectionController.invite(to: peerID)
+    }
+    
+    func disconnectToPeerDevice() {
+        self.peerConnectionController.disconnectToPeerDevice()
+    }
+    
+    func setIsSupportedNearbyInteraction() {
+        self.isShowAlert = NearbyInteractionManager.isSupportedNearbyInteraction() == false
+    }
 }
 
 private extension PeerListViewModel {

--- a/2022/Playgrounds/CheeringCard/PeerListViewModel.swift
+++ b/2022/Playgrounds/CheeringCard/PeerListViewModel.swift
@@ -14,10 +14,10 @@ final class PeerListViewModel: ObservableObject {
     // MARK: - properties
     
     private var peerConnectionController: PeerConnectionController
-    @Published var isNearbySessionEstablished: Bool = false
-    @Published var distanceToPeerDevice: String = ""
-    @Published var peerName: String = ""
-    @Published var peers: [Peer] = []
+    @Published private(set) var isNearbySessionEstablished: Bool = false
+    @Published private(set) var distanceToPeerDevice: String = ""
+    @Published private(set) var peerName: String = ""
+    @Published private(set) var peers: [Peer] = []
     @Published private(set) var isSupportedNearbyInteraction: Bool = false
     @Published var isShowAlert: Bool = false
     

--- a/2022/Playgrounds/CheeringCard/PeerListViewModel.swift
+++ b/2022/Playgrounds/CheeringCard/PeerListViewModel.swift
@@ -54,7 +54,14 @@ private extension PeerListViewModel {
         self.peerConnectionController.$distanceToPeerDevice
             .receive(on: DispatchQueue.main)
             .sink { [weak self] distanceToPeerDevice in
-                
+                self?.setDistanceToPeerDevice(from: distanceToPeerDevice)
             }.store(in: &self.cancellables)
+    }
+    
+    func setDistanceToPeerDevice(from distanceToPeerDevice: Float?) {
+        self.distanceToPeerDevice = String(
+            format: "%0.2f",
+            distanceToPeerDevice ?? 0.0
+        )
     }
 }

--- a/2022/Playgrounds/CheeringCard/PeerListViewModel.swift
+++ b/2022/Playgrounds/CheeringCard/PeerListViewModel.swift
@@ -18,7 +18,6 @@ final class PeerListViewModel: ObservableObject {
     @Published private(set) var distanceToPeerDevice: String = ""
     @Published private(set) var peerName: String = ""
     @Published private(set) var peers: [Peer] = []
-    @Published private(set) var isSupportedNearbyInteraction: Bool = false
     @Published var isShowAlert: Bool = false
     
     private var cancellables = Set<AnyCancellable>()

--- a/2022/Playgrounds/CheeringCard/PeerListViewModel.swift
+++ b/2022/Playgrounds/CheeringCard/PeerListViewModel.swift
@@ -5,4 +5,56 @@
 //  Created by Noah on 2022/11/26.
 //
 
+import Combine
 import Foundation
+import MultipeerConnectivity
+import NearbyInteraction
+
+final class PeerListViewModel: ObservableObject {
+    // MARK: - properties
+    
+    private var peerConnectionController: PeerConnectionController
+    @Published var isNearbySessionEstablished: Bool = false
+    @Published var distanceToPeerDevice: String = ""
+    @Published var peerName: String = ""
+    @Published var peers: [Peer] = []
+    @Published private(set) var isSupportedNearbyInteraction: Bool = false
+    @Published var isShowAlert: Bool = false
+    
+    private var cancellables = Set<AnyCancellable>()
+    
+    init(peerConnectionController: PeerConnectionController) {
+        self.peerConnectionController = peerConnectionController
+        self.bindToPeerConnectionController()
+    }
+}
+
+private extension PeerListViewModel {
+    // MARK: - private func
+    
+    func bindToPeerConnectionController() {
+        self.peerConnectionController.$connectedPeer
+            .receive(on: DispatchQueue.main)
+            .sink(receiveValue: { [weak self] peer in
+            self?.peerName = peer?.displayName ?? ""
+        }).store(in: &self.cancellables)
+        
+        self.peerConnectionController.$peers
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] peers in
+                self?.peers = peers
+            }.store(in: &self.cancellables)
+        
+        self.peerConnectionController.$isNISessionEstablished
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] isNISessionEstablished in
+                self?.isNearbySessionEstablished = isNISessionEstablished
+            }.store(in: &self.cancellables)
+        
+        self.peerConnectionController.$distanceToPeerDevice
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] distanceToPeerDevice in
+                
+            }.store(in: &self.cancellables)
+    }
+}

--- a/2022/Utility/UICollectionReusableView+Extension.swift
+++ b/2022/Utility/UICollectionReusableView+Extension.swift
@@ -1,0 +1,15 @@
+//
+//  UICollectionReusableView+Extension.swift
+//  LetSwift
+//
+//  Created by Noah on 2022/11/26.
+//
+
+import UIKit
+
+extension UICollectionReusableView {
+    override open var backgroundColor: UIColor? {
+        get { .clear }
+        set { }
+    }
+}

--- a/LetSwift.xcodeproj/project.pbxproj
+++ b/LetSwift.xcodeproj/project.pbxproj
@@ -121,6 +121,7 @@
 		16DBE6CB256A2EC800B334A3 /* Application.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16DBE6C8256A2EC800B334A3 /* Application.swift */; };
 		16DBE6CC256A2EC800B334A3 /* Color.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16DBE6C9256A2EC800B334A3 /* Color.swift */; };
 		3C07063899855A671DDB6508 /* Pods_LetSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8ACD22972F91777DDDC6609F /* Pods_LetSwift.framework */; };
+		4F74A95529314B76003311E8 /* PeerListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F74A95429314B76003311E8 /* PeerListViewModel.swift */; };
 		4FFB9A93292F592000182AA4 /* Peer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FFB9A92292F592000182AA4 /* Peer.swift */; };
 		4FFB9A95292F907200182AA4 /* MultipeerConnectivityManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FFB9A94292F907200182AA4 /* MultipeerConnectivityManager.swift */; };
 		4FFB9A97292F9FA800182AA4 /* NearbyInteractionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FFB9A96292F9FA800182AA4 /* NearbyInteractionManager.swift */; };
@@ -405,6 +406,7 @@
 		1F3309A495A5037695D25036 /* Pods_Upcoming1WidgetExtension.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Upcoming1WidgetExtension.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		2CEE5D31BF7A0CE9C14548DD /* Pods-Upcoming2WidgetExtension.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Upcoming2WidgetExtension.debug.xcconfig"; path = "Target Support Files/Pods-Upcoming2WidgetExtension/Pods-Upcoming2WidgetExtension.debug.xcconfig"; sourceTree = "<group>"; };
 		34AF4FE1450E9DA065A22F07 /* Pods-Upcoming2WidgetExtension.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Upcoming2WidgetExtension.release.xcconfig"; path = "Target Support Files/Pods-Upcoming2WidgetExtension/Pods-Upcoming2WidgetExtension.release.xcconfig"; sourceTree = "<group>"; };
+		4F74A95429314B76003311E8 /* PeerListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeerListViewModel.swift; sourceTree = "<group>"; };
 		4FFB9A92292F592000182AA4 /* Peer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Peer.swift; sourceTree = "<group>"; };
 		4FFB9A94292F907200182AA4 /* MultipeerConnectivityManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultipeerConnectivityManager.swift; sourceTree = "<group>"; };
 		4FFB9A96292F9FA800182AA4 /* NearbyInteractionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NearbyInteractionManager.swift; sourceTree = "<group>"; };
@@ -929,6 +931,7 @@
 			isa = PBXGroup;
 			children = (
 				4FFB9A81292CDA1B00182AA4 /* PeerConnection */,
+				4F74A95429314B76003311E8 /* PeerListViewModel.swift */,
 				555CB617291CC3B700D893CE /* NicknameView.swift */,
 				555CB616291CC3B700D893CE /* SurveyView.swift */,
 				555CB615291CC3B700D893CE /* AnswerItemView.swift */,
@@ -1738,6 +1741,7 @@
 				16984E7B256A33AE0011C872 /* CalendarManager.swift in Sources */,
 				60E1766A256D4FBE0068B3F4 /* Event.swift in Sources */,
 				C6CDB2D9292B09F000960FBF /* SessionDetailView.swift in Sources */,
+				4F74A95529314B76003311E8 /* PeerListViewModel.swift in Sources */,
 				16DBE6A8256A279B00B334A3 /* ScheduleView.swift in Sources */,
 				555CB611291CC38B00D893CE /* GoToCardView.swift in Sources */,
 				6FC0FD0D2923F5FB0026714A /* CommentResponse.swift in Sources */,

--- a/LetSwift.xcodeproj/project.pbxproj
+++ b/LetSwift.xcodeproj/project.pbxproj
@@ -123,6 +123,7 @@
 		3C07063899855A671DDB6508 /* Pods_LetSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8ACD22972F91777DDDC6609F /* Pods_LetSwift.framework */; };
 		4F74A95529314B76003311E8 /* PeerListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F74A95429314B76003311E8 /* PeerListViewModel.swift */; };
 		4F74A95729314E6C003311E8 /* PeerListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F74A95629314E6C003311E8 /* PeerListView.swift */; };
+		4F74A9592931510E003311E8 /* UICollectionReusableView+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F74A9582931510E003311E8 /* UICollectionReusableView+Extension.swift */; };
 		4FFB9A93292F592000182AA4 /* Peer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FFB9A92292F592000182AA4 /* Peer.swift */; };
 		4FFB9A95292F907200182AA4 /* MultipeerConnectivityManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FFB9A94292F907200182AA4 /* MultipeerConnectivityManager.swift */; };
 		4FFB9A97292F9FA800182AA4 /* NearbyInteractionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FFB9A96292F9FA800182AA4 /* NearbyInteractionManager.swift */; };
@@ -409,6 +410,7 @@
 		34AF4FE1450E9DA065A22F07 /* Pods-Upcoming2WidgetExtension.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Upcoming2WidgetExtension.release.xcconfig"; path = "Target Support Files/Pods-Upcoming2WidgetExtension/Pods-Upcoming2WidgetExtension.release.xcconfig"; sourceTree = "<group>"; };
 		4F74A95429314B76003311E8 /* PeerListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeerListViewModel.swift; sourceTree = "<group>"; };
 		4F74A95629314E6C003311E8 /* PeerListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeerListView.swift; sourceTree = "<group>"; };
+		4F74A9582931510E003311E8 /* UICollectionReusableView+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UICollectionReusableView+Extension.swift"; sourceTree = "<group>"; };
 		4FFB9A92292F592000182AA4 /* Peer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Peer.swift; sourceTree = "<group>"; };
 		4FFB9A94292F907200182AA4 /* MultipeerConnectivityManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultipeerConnectivityManager.swift; sourceTree = "<group>"; };
 		4FFB9A96292F9FA800182AA4 /* NearbyInteractionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NearbyInteractionManager.swift; sourceTree = "<group>"; };
@@ -1253,6 +1255,7 @@
 				6FE5D037291F8E09001F6880 /* IndicatorView.swift */,
 				6FE5D039291F9F2C001F6880 /* Toast.swift */,
 				6FC0FD162925D2AD0026714A /* LifeCycle+Modifier.swift */,
+				4F74A9582931510E003311E8 /* UICollectionReusableView+Extension.swift */,
 			);
 			path = Utility;
 			sourceTree = "<group>";
@@ -1819,6 +1822,7 @@
 				1624BF8A256C4A3700634E29 /* AppSourceCodeItemView.swift in Sources */,
 				C63C5C91291AA26A00DAD52C /* PlaceType.swift in Sources */,
 				C6CDB2D12928DFEF00960FBF /* SessionInformationModel.swift in Sources */,
+				4F74A9592931510E003311E8 /* UICollectionReusableView+Extension.swift in Sources */,
 				6FC0FD2F2927C55C0026714A /* QuestionInfoView.swift in Sources */,
 				6F3A3E3E2917418300E42D64 /* GuestBookRow.swift in Sources */,
 				6054DA75256A53D500A49BD4 /* EventItemView.swift in Sources */,

--- a/LetSwift.xcodeproj/project.pbxproj
+++ b/LetSwift.xcodeproj/project.pbxproj
@@ -122,6 +122,7 @@
 		16DBE6CC256A2EC800B334A3 /* Color.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16DBE6C9256A2EC800B334A3 /* Color.swift */; };
 		3C07063899855A671DDB6508 /* Pods_LetSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8ACD22972F91777DDDC6609F /* Pods_LetSwift.framework */; };
 		4F74A95529314B76003311E8 /* PeerListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F74A95429314B76003311E8 /* PeerListViewModel.swift */; };
+		4F74A95729314E6C003311E8 /* PeerListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F74A95629314E6C003311E8 /* PeerListView.swift */; };
 		4FFB9A93292F592000182AA4 /* Peer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FFB9A92292F592000182AA4 /* Peer.swift */; };
 		4FFB9A95292F907200182AA4 /* MultipeerConnectivityManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FFB9A94292F907200182AA4 /* MultipeerConnectivityManager.swift */; };
 		4FFB9A97292F9FA800182AA4 /* NearbyInteractionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FFB9A96292F9FA800182AA4 /* NearbyInteractionManager.swift */; };
@@ -407,6 +408,7 @@
 		2CEE5D31BF7A0CE9C14548DD /* Pods-Upcoming2WidgetExtension.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Upcoming2WidgetExtension.debug.xcconfig"; path = "Target Support Files/Pods-Upcoming2WidgetExtension/Pods-Upcoming2WidgetExtension.debug.xcconfig"; sourceTree = "<group>"; };
 		34AF4FE1450E9DA065A22F07 /* Pods-Upcoming2WidgetExtension.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Upcoming2WidgetExtension.release.xcconfig"; path = "Target Support Files/Pods-Upcoming2WidgetExtension/Pods-Upcoming2WidgetExtension.release.xcconfig"; sourceTree = "<group>"; };
 		4F74A95429314B76003311E8 /* PeerListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeerListViewModel.swift; sourceTree = "<group>"; };
+		4F74A95629314E6C003311E8 /* PeerListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeerListView.swift; sourceTree = "<group>"; };
 		4FFB9A92292F592000182AA4 /* Peer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Peer.swift; sourceTree = "<group>"; };
 		4FFB9A94292F907200182AA4 /* MultipeerConnectivityManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultipeerConnectivityManager.swift; sourceTree = "<group>"; };
 		4FFB9A96292F9FA800182AA4 /* NearbyInteractionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NearbyInteractionManager.swift; sourceTree = "<group>"; };
@@ -932,6 +934,7 @@
 			children = (
 				4FFB9A81292CDA1B00182AA4 /* PeerConnection */,
 				4F74A95429314B76003311E8 /* PeerListViewModel.swift */,
+				4F74A95629314E6C003311E8 /* PeerListView.swift */,
 				555CB617291CC3B700D893CE /* NicknameView.swift */,
 				555CB616291CC3B700D893CE /* SurveyView.swift */,
 				555CB615291CC3B700D893CE /* AnswerItemView.swift */,
@@ -1753,6 +1756,7 @@
 				1684F667257244F900A784C0 /* Bundle.swift in Sources */,
 				16DBE6CA256A2EC800B334A3 /* OSLog.swift in Sources */,
 				16984E76256A33970011C872 /* Safari.swift in Sources */,
+				4F74A95729314E6C003311E8 /* PeerListView.swift in Sources */,
 				AECAE6CE292CBF92007A0BFB /* Model.swift in Sources */,
 				16A27AC82570AFC700D7C664 /* OnAirIconView.swift in Sources */,
 				C63C5C85291A894200DAD52C /* imageExtension.swift in Sources */,


### PR DESCRIPTION
### 구현한 내용
- [x] https://github.com/letswiftconf/LetSwift/pull/154 에서 구현한 PeerConnectionController를 이용해 사용자간 연결을 구현하였습니다.
- [x] 응원카드 타입이 같은 사용자의 목록을 나타내는 화면을 구현하였습니다.
- [x] 사용자와 NearbyInteraction Session이 established 될 경우 사용자와의 거리를 나타내는 화면을 구현하였습니다.
- [x] NearbyInteractionManager을 사용하지 못하는 경우 alert을 띄우도록 하였습니다.

용운님과 함께 교차검증한 결과 실기기에서는 잘 동작하지만 iOS 16.1 Simulator를 사용할 경우
 `NISession()`객체 생성 시 앱이 비정상 종료되는 이슈를 확인하였습니다.

[Apple의 NearbyInteraction 예제코드](https://developer.apple.com/documentation/nearbyinteraction/implementing_interactions_between_users_in_close_proximity) 역시 iOS 16.1 Simulator를 사용할 경우 동일하게 실기기에서는 잘 동작하지만,
`NISession()`객체 생성 시 동일한 증상이 나타나 iOS 16.1 Simulator의 이슈로 판단하였습니다.

SwiftUI가 처음이라 부족한 부분이 많습니다 🥲

### TODO
- 안정성 향상

### 화면
- 아래의 화면은 응원카드가 같은 경우 사용자와의 거리를 나타내는 화면입니다.

| 응원카드가 같은 경우	|
|----------------	|
| ![Screen Recording 2022-11-26 at 5 06 45-min](https://user-images.githubusercontent.com/63908856/204051858-d0c00a27-d4e6-46b4-bd44-0811fb6651d2.gif)|

- 아래의 화면은 응원카드가 다른 경우 사용자를 찾지 못하는 화면입니다.

| 응원카드가 다른 경우	|
|----------------	|
| ![Screen Recording 2022-11-26 at 5 08 38 mov](https://user-images.githubusercontent.com/63908856/204051959-8c822e9b-2c11-4c31-b5a5-b970154e1742.gif)|

- 아래의 화면은 NearbyInteraction framework를 사용하지 못하는 기기의 화면입니다.

| NearbyInteraction framework를 사용하지 못하는 기기의 경우 	|
|----------------	|
| <img src="https://user-images.githubusercontent.com/63908856/204052095-333f42c6-31df-45b6-be52-d4660c7fee5c.gif" width="375px"/>
