### PR TITLE
Fix location client

### DIFF
--- a/2022/Location/LocationClient.swift
+++ b/2022/Location/LocationClient.swift
@@ -35,7 +35,7 @@ extension LocationClient {
         return LocationClient { @MainActor [manager] venue in
             manager.checkAuthorizationStatus()
             return try manager.locationStream()
-                .throttle(for: .seconds(2), latest: true)
+                .throttle(for: .seconds(3), latest: true)
                 .map { item in
                     return try await buildCLLocationDistance(
                         location: item,
@@ -43,7 +43,7 @@ extension LocationClient {
                     )
                 }
                 .filter { [manager] in
-                    let flag = $0 > 1
+                    let flag = $0 > 0.5
                     flag ? nil : manager.cancelStream(isFinished: true)
                     return flag
                 }

--- a/2022/Location/LocationStore.swift
+++ b/2022/Location/LocationStore.swift
@@ -8,11 +8,7 @@ class LiveActivityStore: ObservableObject {
     @MainActor @Published var state: State
     private let environmnet: Environment
     
-    private var taskList: [Task<Void, Never>] = [] {
-        didSet {
-            print(taskList.count)
-        }
-    }
+    private var taskList: [Task<Void, Never>] = []
     
     init(
         initialState: State,

--- a/2022/Location/LocationStore.swift
+++ b/2022/Location/LocationStore.swift
@@ -37,10 +37,9 @@ class LiveActivityStore: ObservableObject {
                 
                 for try await item in stream {
                     if self?.state.liveActivity?.activityState == Optional(.active) {
-                        guard
-                            self?.state.liveActivity?.contentState.distance != Optional(item)
-                        else { return }
-                        await self?.state.liveActivity?.update(using: .init(distance: item))
+                        if self?.state.liveActivity?.contentState.distance != Optional(item) {
+                            await self?.state.liveActivity?.update(using: .init(distance: item))
+                        }
                     } else {
                         try self?.buildActivity(distance: item)
                     }

--- a/2022/Location/LocationStore.swift
+++ b/2022/Location/LocationStore.swift
@@ -5,12 +5,20 @@ import SwiftUI
 
 @available(iOS 16.1, *)
 class LiveActivityStore: ObservableObject {
-    @MainActor @Published var state = false
-    private var activity: Activity<LocationAttributes>?
-    private var taskList: [Task<Void, Never>] = []
+    @MainActor @Published var state: State
     private let environmnet: Environment
     
-    init(environment: Environment) {
+    private var taskList: [Task<Void, Never>] = [] {
+        didSet {
+            print(taskList.count)
+        }
+    }
+    
+    init(
+        initialState: State,
+        environment: Environment
+    ) {
+        self._state = .init(initialValue: initialState)
         self.environmnet = environment
     }
     
@@ -18,67 +26,60 @@ class LiveActivityStore: ObservableObject {
         guard
             taskList.isEmpty
         else {
-            environmnet.locationClient.cancelStream()
+            environmnet.locationClient.cancelStream(false)
+            Task { @MainActor [weak self] in
+                self?.state.isLiveActivityVisible = false
+            }
             return
         }
-        let task = Task {
+        let task = Task { @MainActor [weak self, environmnet] in
             do {
-                await toggle(item: true)
+                self?.state.isLiveActivityVisible = true
                 let stream = try await environmnet
                     .locationClient
                     .distanceStream(.aTCenter)
                 
                 for try await item in stream {
-                    if activity?.activityState == Optional(.active) {
-                        await activity?.update(using: .init(movingState: .going(item)))
+                    if self?.state.liveActivity?.activityState == Optional(.active) {
+                        guard
+                            self?.state.liveActivity?.contentState.distance != Optional(item)
+                        else { return }
+                        await self?.state.liveActivity?.update(using: .init(distance: item))
                     } else {
-                        try buildActivity(item: item)
+                        try self?.buildActivity(distance: item)
                     }
                 }
-                await toggle(item: false)
-                await activity?.update(using: .init(movingState: .arrived))
+                self?.cancelTasks()
+                await self?.state.liveActivity?.update(using: .init(isArrived: true))
+            } catch is CancellationError {
+                self?.cancelTasks()
+                await self?.state.liveActivity?.end(dismissalPolicy: .immediate)
             } catch {
-                guard
-                    !(error is CancellationError)
-                else {
-                    await toggle(item: false)
-                    for _ in 0..<taskList.count {
-                        taskList.removeFirst().cancel()
-                    }
-                    await activity?.end(dismissalPolicy: .immediate)
-                    return
-                }
-                print("💥", error)
+                self?.cancelTasks(error: error)
             }
         }
         taskList.append(task)
     }
     
-    private func buildActivity(item: Double) throws {
-        activity = try .request(
+    @MainActor
+    private func buildActivity(distance: Double) throws {
+        state.liveActivity = try .request(
             attributes: .init(),
-            contentState: .init(movingState: .going(item))
+            contentState: .init(distance: distance)
         )
-        let task = Task { [activity, weak self] in
-            guard let self = self else { return }
-            if let activity {
-                for await activityState in activity.activityStateUpdates {
+        let task = Task { [weak self, state, environmnet] in
+            if let liveActivity = state.liveActivity {
+                for await activityState in liveActivity.activityStateUpdates {
                     switch activityState {
                     case .active:
                         break
                         
                     case .ended:
-                        await toggle(item: false)
-                        for _ in 0..<self.taskList.count {
-                            self.taskList.removeFirst().cancel()
-                        }
+                        self?.cancelTasks()
                         
                     case .dismissed:
-                        await toggle(item: false)
-                        environmnet.locationClient.cancelStream()
-                        for _ in 0..<self.taskList.count {
-                            self.taskList.removeFirst().cancel()
-                        }
+                        environmnet.locationClient.cancelStream(false)
+                        self?.cancelTasks()
                         
                     default:
                         break
@@ -90,16 +91,27 @@ class LiveActivityStore: ObservableObject {
     }
     
     @MainActor
-    private func toggle(item: Bool) {
-        withAnimation {
-            state = item
-        }
+    private func cancelTasks(error: Error? = nil) {
+        state.isLiveActivityVisible = false
+        taskList.indices
+            .forEach { [weak self] _ in self?.taskList.removeFirst().cancel() }
+        state.error = error
     }
 }
 
 @available(iOS 16.1, *)
 extension LiveActivityStore {
-    static let live = LiveActivityStore(environment: .live)
+    static let live = LiveActivityStore(
+        initialState: .init(),
+        environment: .live
+    )
+    
+    struct State {
+        var isLiveActivityVisible: Bool = false
+        var isButtonVisible: Bool = true
+        var liveActivity: Activity<LocationAttributes>?
+        var error: Error?
+    }
     
     struct Environment {
         static let live = Self(locationClient: .live)

--- a/2022/Location/Model.swift
+++ b/2022/Location/Model.swift
@@ -3,14 +3,8 @@ import Foundation
 
 struct LocationAttributes: ActivityAttributes {
     struct ContentState: Codable, Hashable {
-        let movingState: MovingState
-    }
-}
-
-extension LocationAttributes {
-    enum MovingState: Codable, Hashable {
-        case going(Double)
-        case arrived
+        var distance: Double = .zero
+        var isArrived: Bool = false
     }
 }
 

--- a/2022/Location/SessionFloatingButton.swift
+++ b/2022/Location/SessionFloatingButton.swift
@@ -6,7 +6,10 @@ struct SessionFloatingButton: View {
     
     var body: some View {
         Button(action: store.buttonTapped) {
-            Text("\(store.state ? "DeActivate" : "Activate") Live Activitiy")
+            let text = store.state.isLiveActivityVisible ?
+            "DeActivate" :
+            "Activate"
+            Text("\(text) Live Activitiy")
                 .font(.bodyBold)
                 .padding()
                 .foregroundColor(.white)
@@ -14,5 +17,16 @@ struct SessionFloatingButton: View {
                 .cornerRadius(10)
         }
         .padding(.trailing, 8)
+        .opacity(store.state.isButtonVisible ? 1.0 : .zero)
+        .alert(
+            "알림",
+            isPresented: .constant(store.state.error != nil)
+        ) {
+            Button(action: { store.state.error = nil }) {
+                Text("확인")
+            }
+        } message: {
+            Text(store.state.error?.localizedDescription ?? "잠시 후 다시 시도해주세요.")
+        }
     }
 }

--- a/LocationWidget/LocationWidgetLiveActivity.swift
+++ b/LocationWidget/LocationWidgetLiveActivity.swift
@@ -5,7 +5,7 @@ import SwiftUI
 struct LocationWidgetLiveActivity: Widget {
     var body: some WidgetConfiguration {
         ActivityConfiguration(for: LocationAttributes.self) { context in
-            LocationLockScreenBannerView(state: context.state.movingState)
+            LocationLockScreenBannerView(state: context.state)
         } dynamicIsland: { context in
             /// MARK: - DynamicIsland는 추가 구현이 필요한 상태.
             DynamicIsland {
@@ -30,12 +30,14 @@ struct LocationWidgetLiveActivity: Widget {
 }
 
 struct LocationLockScreenBannerView: View {
-    let state: LocationAttributes.MovingState
+    let state: LocationAttributes.ContentState
     
     var body: some View {
         ZStack(alignment: .leading) {
-            switch state {
-            case let .going(distance):
+            if state.isArrived {
+                Image("arrivedLockScreenBanner")
+                    .resizable()
+            } else {
                 Image("lockScreenBannerBackground")
                     .resizable()
                 
@@ -45,7 +47,7 @@ struct LocationLockScreenBannerView: View {
                         .foregroundColor(Color(hex: "545454"))
                     
                     HStack(alignment: .firstTextBaseline, spacing: 15) {
-                        Text("\(distance, specifier: "%.2f")")
+                        Text("\(state.distance, specifier: "%.2f")")
                             .font(.custom("Poppins-ExtraBold", size: 42))
                         
                         Text("km")
@@ -54,10 +56,6 @@ struct LocationLockScreenBannerView: View {
                     .foregroundColor(Color(hex: "0A0A0A"))
                 }
                 .padding(.leading, 28)
-                
-            case .arrived:
-                Image("arrivedLockScreenBanner")
-                    .resizable()
             }
         }
         .frame(height: 130)


### PR DESCRIPTION
### Location Client에서 값을 방출하지 못하던 문제 수정
debounce의 잘못된 사용으로 인해서 값을 방출하지 못하는 상황이였습니다.(이로 인해서 현재 심사에 반영된 코드는 무한 대기상태인 경우가 많습니다.) 이를 throttle로 변경함으로써 정상적으로 값을 방출할 수 있도록 수정했습니다.

<br>

### 에러 핸들링 추가
Location Store에서 발생할 수 있는 확인 된 에러는 총 3가지 입니다.
해당 에러가 발생했을때, 알림으로 사용자에게 문제가 발생했다고 확인할 수 있도록 구현했습니다.
- Location
- Live Activities
- Cellular Data
<br>


### 거리 비교 값 수정
생각보다 위치를 비교하는 값이 정확해서 1km미터의 비교 값을 0.5km로 수정했습니다.
해당 부분은 직접 행사장까지 테스트 못해본 점이 너무 아쉽습니다. 
서버로 부터 데이터를 받아서 비교할 수 있었지만, 준비 못한점이 아쉽습니다.