### PR TITLE
Fix README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Let'Swift
 
-This is the official Let'Swift iOS app for Let'Swift conference held annully in Seoul, Korea.
+This is the official Let'Swift iOS app for the Let'Swift conference held annually in Seoul, Korea.
 
 <a href="https://apps.apple.com/us/app/letswift/id1282995254?itsct=apps_box&amp;itscg=30200" style="display: inline-block; overflow: hidden; border-top-left-radius: 13px; border-top-right-radius: 13px; border-bottom-right-radius: 13px; border-bottom-left-radius: 13px; width: 250px; height: 83px;"><img src="https://tools.applemediaservices.com/api/badges/download-on-the-app-store/white/ko-KR?size=250x83&amp;releaseDate=1505952000&h=672ebf0bc6d87e10853c611d68587a55" alt="Download on the App Store" style="border-top-left-radius: 13px; border-top-right-radius: 13px; border-bottom-right-radius: 13px; border-bottom-left-radius: 13px; width: 250px; height: 83px;"></a>
 


### PR DESCRIPTION
## Summary
- fix 'annully' typo in README

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68564183b5048326b09a07209045e466