### PR TITLE
firebase 사용 설정 비활성화합니다. 

### DIFF
--- a/LetSwift/AppDelegate.swift
+++ b/LetSwift/AppDelegate.swift
@@ -22,7 +22,8 @@ class AppDelegate: NSObject, UIApplicationDelegate {
     }
 
     private func initializeApp(_ application: UIApplication) {
-        FirebaseApp.configure()
+        // GoogleService-info.plist 파일 추가되면 활성화합니다.
+//        FirebaseApp.configure()
 
         // 앱 실행 시 사용자에게 알림 허용 권한을 받음
         UNUserNotificationCenter.current().delegate = self


### PR DESCRIPTION
GoogleService-info.plist 파일이 없어 런치시 크래시나서, 
개발 편의를 위해 GoogleService-info.plist 파일이 추가되기 전까지 비활성화 처리해둡니다. 
@loinsir 