### PR TITLE
Allow feedback survey in settings ony after Nov 24th

### DIFF
--- a/LetSwift/Resources/Localizable.xcstrings
+++ b/LetSwift/Resources/Localizable.xcstrings
@@ -441,6 +441,23 @@
         }
       }
     },
+    "settings.survey.unavailable" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "You can participate in the survey on the conference day."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "행사 당일부터 참여할 수 있어요."
+          }
+        }
+      }
+    },
     "settings.title" : {
       "localizations" : {
         "en" : {

--- a/LetSwift/Views/More/MoreView.swift
+++ b/LetSwift/Views/More/MoreView.swift
@@ -10,9 +10,10 @@ import BetterSafariView
 
 struct MoreView: View {
     @Environment(\.openURL) private var openURL
-    
+
     @State private var presentURL: URL? = nil
-    
+    @State private var showSurveyUnavailableAlert = false
+
     var body: some View {
         NavigationStack {
             List {
@@ -30,6 +31,9 @@ struct MoreView: View {
             SafariView(url: item, configuration: .init(entersReaderIfAvailable: false, barCollapsingEnabled: true))
                 .preferredControlAccentColor(.themePrimary)
                 .dismissButtonStyle(.close)
+        }
+        .alert("settings.survey.unavailable", isPresented: $showSurveyUnavailableAlert) {
+            Button("OK", role: .cancel) { }
         }
     }
     
@@ -50,7 +54,7 @@ struct MoreView: View {
             }
             .buttonStyle(.plain)
             Button {
-                present(url: URL.letswiftReview)
+                presentSurveyIfAvailable()
             } label: {
                 ListItem(title: "settings.conferenceReview", style: .externalLink)
             }
@@ -127,6 +131,24 @@ struct MoreView: View {
         }
         presentURL = url
 //        openURL(url)
+    }
+
+    private func presentSurveyIfAvailable() {
+        let currentDate = Date()
+        let calendar = Calendar.current
+
+        // Survey available date: November 24, 2025
+        let components = DateComponents(year: 2025, month: 11, day: 24)
+        guard let surveyAvailableDate = calendar.date(from: components) else {
+            return
+        }
+
+        // Check if current date is on or after November 24, 2025
+        if currentDate >= surveyAvailableDate {
+            present(url: URL.letswiftReview)
+        } else {
+            showSurveyUnavailableAlert = true
+        }
     }
 }
 


### PR DESCRIPTION
- Add date check before showing feedback survey
- Survey only available on/after November 24, 2025
- Show alert with localized message when unavailable
- Add settings.survey.unavailable localization key (ko/en)