### PR TITLE
Hide start Live Activity button on macOS and visionOS

### DIFF
--- a/LetSwift/Views/Session/SessionView.swift
+++ b/LetSwift/Views/Session/SessionView.swift
@@ -13,7 +13,9 @@ struct SessionView: View {
     var body: some View {
         VStack(spacing: 0) {
             tabView
+            #if os(iOS) && !targetEnvironment(macCatalyst)
             liveActivityToggle
+            #endif
             sessionList
         }
         .padding(.top, 20)

--- a/LetSwift/Views/Session/SessionView.swift
+++ b/LetSwift/Views/Session/SessionView.swift
@@ -13,8 +13,10 @@ struct SessionView: View {
     var body: some View {
         VStack(spacing: 0) {
             tabView
-            #if os(iOS) && !targetEnvironment(macCatalyst)
-            liveActivityToggle
+            #if !os(visionOS)
+            if !ProcessInfo.processInfo.isiOSAppOnMac {
+                liveActivityToggle
+            }
             #endif
             sessionList
         }


### PR DESCRIPTION
Hide the Live Activity toggle button and section in the Schedule tab when running on visionOS or macOS (Mac Catalyst). Live Activity is only supported on native iOS devices.