### PR TITLE
워치 스마트 스택에서 라이브 액티비티 아이콘 및 텍스트 크기 최적화

### DIFF
--- a/LetSwift-iOS-Widget/LetSwift_iOS_WidgetLiveActivity.swift
+++ b/LetSwift-iOS-Widget/LetSwift_iOS_WidgetLiveActivity.swift
@@ -11,82 +11,17 @@ import SwiftUI
 
 struct LetSwift_iOS_WidgetLiveActivity: Widget {
     var body: some WidgetConfiguration {
-        ActivityConfiguration(for: PresentationAttributes.self) { context in
-            HStack(alignment: .top, spacing: 8) {
-                Image(.logo2025200)
-                    .resizable()
-                    .scaledToFit()
-                    .frame(width: 52, height: 52)
-                    .clipShape(Circle())
-                    .overlay(
-                        Circle()
-                            .stroke(context.state.currentStatus == .upcoming ? Color(.upcoming) : Color(.themePrimary), lineWidth: 3)
-                    )
-                    .overlay(alignment: .bottomTrailing) {
-                        Circle()
-                            .fill(context.state.currentStatus == .upcoming ? Color(.upcoming) : Color(.themePrimary))
-                            .frame(width: 18, height: 18)
-                            .overlay(
-                                Image(systemName: "clock")
-                                    .resizable()
-                                    .frame(width: 13, height: 12)
-                                    .foregroundColor(.white)
-                            )
-                    }
-                
-                VStack(alignment: .leading, spacing: 4) {
-                    HStack(spacing: 0) {
-                        Text(context.state.title)
-                            .font(.system(size: 15, weight: .bold))
-                            .foregroundStyle(Color.white)
-                        
-                        Spacer()
-                        
-                        if let location = context.state.location {
-                            Text(location)
-                                .font(.system(size: 10))
-                                .foregroundStyle(Color.white.opacity(0.6))
-                        }
-                    }
-                    
-                    Text(context.state.speakers.map(\.name).joined(separator: ", "))
-                        .font(.system(size: 14))
-                        .foregroundStyle(Color.white)
-                    
-                    switch context.state.currentStatus {
-                    case .upcoming:
-                        Text("세션이 곧 시작할 예정입니다.")
-                            .font(.system(size: 10, weight: .bold))
-                            .foregroundStyle(Color.white.opacity(0.6))
-
-                    case .ongoing:
-                        if let startDate = parseDate(from: context.state.startTime),
-                           let endDate = parseDate(from: context.state.endTime) {
-                            ProgressView(
-                                timerInterval: startDate...endDate,
-                                countsDown: false,
-                                label: { EmptyView() },
-                                currentValueLabel: {
-                                    Text(startDate, style: .time) + Text(" ~ ") + Text(endDate, style: .time)
-                                }
-                            )
-                            .progressViewStyle(.linear)
-                            .tint(Color(.themePrimary))
-                            .padding(.top, 10)
-                        } else {
-                            Text("진행 중")
-                                .font(.system(size: 10, weight: .bold))
-                                .foregroundStyle(Color.white.opacity(0.6))
-                        }
-
-                    default:
-                        EmptyView()
-                    }
-                }
+        let configuration = ActivityConfiguration(for: PresentationAttributes.self) { context in
+            if #available(iOS 18.0, *) {
+                LiveActivityContentView(context: context)
+            } else {
+                LiveActivityBaseView(
+                    context: context,
+                    iconSize: 52,
+                    badgeSize: 18,
+                    clockIconSize: 13
+                )
             }
-            .padding()
-            .activitySystemActionForegroundColor(Color.white)
-            .activityBackgroundTint(Color.black.opacity(0.7))
         } dynamicIsland: { context in
             DynamicIsland {
                 // Expanded view
@@ -237,6 +172,201 @@ struct LetSwift_iOS_WidgetLiveActivity: Widget {
                         .foregroundColor(Color(.upcoming))
                 }
             }
+        }
+        
+        if #available(iOS 18.0, *) {
+            return configuration
+                .supplementalActivityFamilies([.small, .medium])
+        } else {
+            return configuration
+        }
+    }
+
+    private func parseDate(from dateString: String) -> Date? {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withDashSeparatorInDate, .withColonSeparatorInTime]
+
+        // Try with timezone first
+        if let date = formatter.date(from: dateString) {
+            return date
+        }
+
+        // Try without timezone (add Z)
+        if let date = formatter.date(from: dateString + "Z") {
+            return date
+        }
+
+        // Fallback to DateFormatter
+        let fallbackFormatter = DateFormatter()
+        fallbackFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss"
+        fallbackFormatter.timeZone = TimeZone.current
+        return fallbackFormatter.date(from: dateString)
+    }
+}
+
+// MARK: - Live Activity Content View
+@available(iOS 18.0, *)
+private struct LiveActivityContentView: View {
+    let context: ActivityViewContext<PresentationAttributes>
+    @Environment(\.activityFamily) private var activityFamily
+
+    // 스마트 스택에서는 작은 아이콘, 일반 라이브 액티비티에서는 기본 크기
+    private var isSmartStack: Bool {
+        activityFamily == .small || activityFamily == .medium
+    }
+
+    private var iconSize: CGFloat {
+        isSmartStack ? 28 : 52
+    }
+
+    private var badgeSize: CGFloat {
+        isSmartStack ? 12 : 18
+    }
+
+    private var clockIconSize: CGFloat {
+        isSmartStack ? 8 : 13
+    }
+
+    var body: some View {
+        LiveActivityBaseView(
+            context: context,
+            iconSize: iconSize,
+            badgeSize: badgeSize,
+            clockIconSize: clockIconSize,
+            isCompact: isSmartStack
+        )
+    }
+}
+
+// MARK: - Live Activity Base View
+private struct LiveActivityBaseView: View {
+    let context: ActivityViewContext<PresentationAttributes>
+    let iconSize: CGFloat
+    let badgeSize: CGFloat
+    let clockIconSize: CGFloat
+    var isCompact: Bool = false
+
+    var body: some View {
+        HStack(alignment: .top, spacing: isCompact ? 6 : 8) {
+            LiveActivityIconView(
+                status: context.state.currentStatus,
+                iconSize: iconSize,
+                badgeSize: badgeSize,
+                clockIconSize: clockIconSize
+            )
+
+            LiveActivityTextContentView(context: context, isCompact: isCompact)
+        }
+        .padding(isCompact ? 8 : 12)
+        .activitySystemActionForegroundColor(Color.white)
+        .activityBackgroundTint(Color.black.opacity(0.7))
+    }
+}
+
+// MARK: - Live Activity Icon View
+private struct LiveActivityIconView: View {
+    let status: PresentationAttributes.ContentState.Status
+    let iconSize: CGFloat
+    let badgeSize: CGFloat
+    let clockIconSize: CGFloat
+
+    var body: some View {
+        Image(.logo2025200)
+            .resizable()
+            .scaledToFit()
+            .frame(width: iconSize, height: iconSize)
+            .clipShape(Circle())
+            .overlay(
+                Circle()
+                    .stroke(status == .upcoming ? Color(.upcoming) : Color(.themePrimary), lineWidth: 3)
+            )
+            .overlay(alignment: .bottomTrailing) {
+                Circle()
+                    .fill(status == .upcoming ? Color(.upcoming) : Color(.themePrimary))
+                    .frame(width: badgeSize, height: badgeSize)
+                    .overlay(
+                        Image(systemName: "clock")
+                            .resizable()
+                            .frame(width: clockIconSize, height: clockIconSize - 1)
+                            .foregroundColor(.white)
+                    )
+            }
+    }
+}
+
+// MARK: - Live Activity Text Content View
+private struct LiveActivityTextContentView: View {
+    let context: ActivityViewContext<PresentationAttributes>
+    var isCompact: Bool = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: isCompact ? 2 : 4) {
+            HStack(alignment: .top, spacing: 0) {
+                Text(context.state.title)
+                    .font(.system(size: isCompact ? 10 : 15, weight: .bold))
+                    .foregroundStyle(Color.white)
+                    .lineLimit(2)
+
+                Spacer()
+
+                if let location = context.state.location {
+                    Text(location)
+                        .font(.system(size: isCompact ? 8 : 10))
+                        .foregroundStyle(Color.white.opacity(0.6))
+                        .lineLimit(1)
+                }
+            }
+
+            Text(context.state.speakers.map(\.name).joined(separator: ", "))
+                .font(.system(size: isCompact ? 8 : 14))
+                .foregroundStyle(Color.white)
+                .lineLimit(1)
+
+            LiveActivityStatusView(context: context, isCompact: isCompact)
+        }
+    }
+}
+
+// MARK: - Live Activity Status View
+private struct LiveActivityStatusView: View {
+    let context: ActivityViewContext<PresentationAttributes>
+    var isCompact: Bool = false
+
+    var body: some View {
+        switch context.state.currentStatus {
+        case .upcoming:
+            Text(isCompact ? "곧 시작" : "세션이 곧 시작할 예정입니다.")
+                .font(.system(size: isCompact ? 8 : 10, weight: .bold))
+                .foregroundStyle(Color.white.opacity(0.6))
+                .lineLimit(1)
+
+        case .ongoing:
+            if let startDate = parseDate(from: context.state.startTime),
+               let endDate = parseDate(from: context.state.endTime) {
+                ProgressView(
+                    timerInterval: startDate...endDate,
+                    countsDown: false,
+                    label: { EmptyView() },
+                    currentValueLabel: {
+                        if isCompact {
+                            EmptyView()
+                        } else {
+                            Text(startDate, style: .time) + Text(" ~ ") + Text(endDate, style: .time)
+                        }
+                    }
+                )
+                .progressViewStyle(.linear)
+                .tint(Color(.themePrimary))
+                .padding(.top, isCompact ? 4 : 10)
+            } else {
+                Text("진행 중")
+                    .font(.system(size: isCompact ? 8 : 10, weight: .bold))
+                    .foregroundStyle(Color.white.opacity(0.6))
+                    .lineLimit(1)
+            }
+
+        default:
+            EmptyView()
         }
     }
 


### PR DESCRIPTION
워치 스마트 스택에서 라이브 액티비티 아이콘 및 텍스트 크기 최적화

- iOS 18.0+ 스마트 스택(.small, .medium)에서 컴팩트 레이아웃 적용
- 아이콘 크기: 스마트 스택 28, 일반 52
- 텍스트 크기: 제목 10/15, 발표자 8/14, 위치 8/10, 상태 8/10
- 제목 2줄 표시 지원으로 긴 세션명 가독성 향상
- 공통 컴포넌트 struct로 분리하여 코드 재사용성 개선